### PR TITLE
Prevent duplicate product batch entries

### DIFF
--- a/src/features/inventory/batches/AddProductBatchPanel.tsx
+++ b/src/features/inventory/batches/AddProductBatchPanel.tsx
@@ -70,25 +70,33 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
         fetchSupplies();
     }, [open]);
 
-    // Fetch batches for selected supply
+    // Fetch batches for selected supply and filter out already added ones
     useEffect(() => {
         if (!selectedSupply) {
             setAvailableBatches([]);
             return;
         }
+
         const fetchBatches = async () => {
             try {
                 const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
                 if (res.ok) {
                     const data = await res.json();
-                    setAvailableBatches(data.batches || []);
+                    const usedBatchIds = supplyEntries
+                        .filter((se) => se.supplyId === selectedSupply)
+                        .map((se) => se.batchId);
+                    const filtered = (data.batches || []).filter(
+                        (b: SupplyBatchOption) => !usedBatchIds.includes(b.id)
+                    );
+                    setAvailableBatches(filtered);
                 }
             } catch (err) {
                 console.error(err);
             }
         };
+
         fetchBatches();
-    }, [selectedSupply]);
+    }, [selectedSupply, supplyEntries]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/src/features/inventory/batches/AddProductBatchPanel.tsx
+++ b/src/features/inventory/batches/AddProductBatchPanel.tsx
@@ -36,6 +36,8 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
     });
 
     const [supplies, setSupplies] = useState<SupplyOption[]>([]);
+    const [filteredSupplies, setFilteredSupplies] = useState<SupplyOption[]>([]);
+    const [supplyBatches, setSupplyBatches] = useState<Record<string, SupplyBatchOption[]>>({});
     const [supplyEntries, setSupplyEntries] = useState<ProductBatchSupply[]>([]);
 
     const [selectedSupply, setSelectedSupply] = useState('');
@@ -70,6 +72,47 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
         fetchSupplies();
     }, [open]);
 
+    // Recompute which supplies have available batches
+    useEffect(() => {
+        if (!open) return;
+        const filtered = supplies.filter((s) => {
+            const batches = supplyBatches[s.id] || [];
+            const usedBatchIds = supplyEntries
+                .filter((se) => se.supplyId === s.id)
+                .map((se) => se.batchId);
+            return batches.some((b) => !usedBatchIds.includes(b.id));
+        });
+        setFilteredSupplies(filtered);
+        if (selectedSupply && !filtered.find((s) => s.id === selectedSupply)) {
+            setSelectedSupply('');
+            setAvailableBatches([]);
+            setSelectedBatch('');
+        }
+    }, [open, supplies, supplyBatches, supplyEntries, selectedSupply]);
+
+    // After supplies load, fetch batches for each supply
+    useEffect(() => {
+        if (!open || supplies.length === 0) return;
+        const fetchAllBatches = async () => {
+            const map: Record<string, SupplyBatchOption[]> = {};
+            await Promise.all(
+                supplies.map(async (s) => {
+                    try {
+                        const res = await fetch(`/api/supplies/batches/?supplyId=${s.id}`);
+                        if (res.ok) {
+                            const data = await res.json();
+                            map[s.id] = data.batches || [];
+                        }
+                    } catch (err) {
+                        console.error(err);
+                    }
+                })
+            );
+            setSupplyBatches(map);
+        };
+        fetchAllBatches();
+    }, [open, supplies]);
+
     // Fetch batches for selected supply and filter out already added ones
     useEffect(() => {
         if (!selectedSupply) {
@@ -77,26 +120,34 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
             return;
         }
 
-        const fetchBatches = async () => {
-            try {
-                const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
-                if (res.ok) {
-                    const data = await res.json();
-                    const usedBatchIds = supplyEntries
-                        .filter((se) => se.supplyId === selectedSupply)
-                        .map((se) => se.batchId);
-                    const filtered = (data.batches || []).filter(
-                        (b: SupplyBatchOption) => !usedBatchIds.includes(b.id)
-                    );
-                    setAvailableBatches(filtered);
+        const loadBatches = async () => {
+            let batches = supplyBatches[selectedSupply];
+            if (!batches) {
+                try {
+                    const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
+                    if (res.ok) {
+                        const data = await res.json();
+                        batches = data.batches || [];
+                        setSupplyBatches((prev) => ({ ...prev, [selectedSupply]: batches! }));
+                    }
+                } catch (err) {
+                    console.error(err);
                 }
-            } catch (err) {
-                console.error(err);
+            }
+
+            if (batches) {
+                const usedBatchIds = supplyEntries
+                    .filter((se) => se.supplyId === selectedSupply)
+                    .map((se) => se.batchId);
+                const filtered = batches.filter(
+                    (b: SupplyBatchOption) => !usedBatchIds.includes(b.id)
+                );
+                setAvailableBatches(filtered);
             }
         };
 
-        fetchBatches();
-    }, [selectedSupply, supplyEntries]);
+        loadBatches();
+    }, [selectedSupply, supplyEntries, supplyBatches]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -191,7 +242,7 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
                     <label className="input-label">Supply name</label>
                     <select className="input-max-width" value={selectedSupply} onChange={e => setSelectedSupply(e.target.value)}>
                         <option value="">Select supply</option>
-                        {supplies.map(s => (
+                        {filteredSupplies.map(s => (
                             <option key={s.id} value={s.id}>{s.supply_name}</option>
                         ))}
                     </select>

--- a/src/features/inventory/batches/EditProductBatchPanel.tsx
+++ b/src/features/inventory/batches/EditProductBatchPanel.tsx
@@ -83,19 +83,27 @@ export default function EditProductBatchPanel({ open, onClose, batch, onUpdated 
             setAvailableBatches([]);
             return;
         }
+
         const fetchBatches = async () => {
             try {
                 const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
                 if (res.ok) {
                     const data = await res.json();
-                    setAvailableBatches(data.batches || []);
+                    const usedBatchIds = supplyEntries
+                        .filter((se) => se.supplyId === selectedSupply)
+                        .map((se) => se.batchId);
+                    const filtered = (data.batches || []).filter(
+                        (b: SupplyBatchOption) => !usedBatchIds.includes(b.id)
+                    );
+                    setAvailableBatches(filtered);
                 }
             } catch (err) {
                 console.error(err);
             }
         };
+
         fetchBatches();
-    }, [selectedSupply]);
+    }, [selectedSupply, supplyEntries]);
 
     const addEntry = () => {
         if (!selectedSupply || !selectedBatch) return;

--- a/src/features/inventory/batches/EditProductBatchPanel.tsx
+++ b/src/features/inventory/batches/EditProductBatchPanel.tsx
@@ -29,6 +29,8 @@ export default function EditProductBatchPanel({ open, onClose, batch, onUpdated 
         is_active: batch.is_active,
     });
     const [supplies, setSupplies] = useState<SupplyOption[]>([]);
+    const [filteredSupplies, setFilteredSupplies] = useState<SupplyOption[]>([]);
+    const [supplyBatches, setSupplyBatches] = useState<Record<string, SupplyBatchOption[]>>({});
     const [supplyEntries, setSupplyEntries] = useState<ProductBatchSupply[]>([]);
     const [selectedSupply, setSelectedSupply] = useState('');
     const [availableBatches, setAvailableBatches] = useState<SupplyBatchOption[]>([]);
@@ -78,32 +80,81 @@ export default function EditProductBatchPanel({ open, onClose, batch, onUpdated 
         fetchSupplies();
     }, [open]);
 
+    // After supplies load, fetch batches for each supply
+    useEffect(() => {
+        if (!open || supplies.length === 0) return;
+        const fetchAllBatches = async () => {
+            const map: Record<string, SupplyBatchOption[]> = {};
+            await Promise.all(
+                supplies.map(async (s) => {
+                    try {
+                        const res = await fetch(`/api/supplies/batches/?supplyId=${s.id}`);
+                        if (res.ok) {
+                            const data = await res.json();
+                            map[s.id] = data.batches || [];
+                        }
+                    } catch (err) {
+                        console.error(err);
+                    }
+                })
+            );
+            setSupplyBatches(map);
+        };
+        fetchAllBatches();
+    }, [open, supplies]);
+
+    // Recompute which supplies still have available batches
+    useEffect(() => {
+        if (!open) return;
+        const filtered = supplies.filter((s) => {
+            const batches = supplyBatches[s.id] || [];
+            const usedBatchIds = supplyEntries
+                .filter((se) => se.supplyId === s.id)
+                .map((se) => se.batchId);
+            return batches.some((b) => !usedBatchIds.includes(b.id));
+        });
+        setFilteredSupplies(filtered);
+        if (selectedSupply && !filtered.find((s) => s.id === selectedSupply)) {
+            setSelectedSupply('');
+            setAvailableBatches([]);
+            setSelectedBatch('');
+        }
+    }, [open, supplies, supplyBatches, supplyEntries, selectedSupply]);
+
     useEffect(() => {
         if (!selectedSupply) {
             setAvailableBatches([]);
             return;
         }
 
-        const fetchBatches = async () => {
-            try {
-                const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
-                if (res.ok) {
-                    const data = await res.json();
-                    const usedBatchIds = supplyEntries
-                        .filter((se) => se.supplyId === selectedSupply)
-                        .map((se) => se.batchId);
-                    const filtered = (data.batches || []).filter(
-                        (b: SupplyBatchOption) => !usedBatchIds.includes(b.id)
-                    );
-                    setAvailableBatches(filtered);
+        const loadBatches = async () => {
+            let batches = supplyBatches[selectedSupply];
+            if (!batches) {
+                try {
+                    const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
+                    if (res.ok) {
+                        const data = await res.json();
+                        batches = data.batches || [];
+                        setSupplyBatches((prev) => ({ ...prev, [selectedSupply]: batches! }));
+                    }
+                } catch (err) {
+                    console.error(err);
                 }
-            } catch (err) {
-                console.error(err);
+            }
+
+            if (batches) {
+                const usedBatchIds = supplyEntries
+                    .filter((se) => se.supplyId === selectedSupply)
+                    .map((se) => se.batchId);
+                const filtered = batches.filter(
+                    (b: SupplyBatchOption) => !usedBatchIds.includes(b.id)
+                );
+                setAvailableBatches(filtered);
             }
         };
 
-        fetchBatches();
-    }, [selectedSupply, supplyEntries]);
+        loadBatches();
+    }, [selectedSupply, supplyEntries, supplyBatches]);
 
     const addEntry = () => {
         if (!selectedSupply || !selectedBatch) return;
@@ -191,7 +242,7 @@ export default function EditProductBatchPanel({ open, onClose, batch, onUpdated 
                     <label className="input-label">Supply</label>
                     <select className="input-max-width" value={selectedSupply} onChange={e => setSelectedSupply(e.target.value)}>
                         <option value="">Select supply</option>
-                        {supplies.map(s => (
+                        {filteredSupplies.map(s => (
                             <option key={s.id} value={s.id}>{s.supply_name}</option>
                         ))}
                     </select>

--- a/src/features/inventory/batches/ProductBatchPanel.tsx
+++ b/src/features/inventory/batches/ProductBatchPanel.tsx
@@ -72,7 +72,10 @@ export default function ProductBatchPanel({ open, onClose, productId, onEditBatc
 
     const formatDate = (dateString: string) => {
         const date = new Date(dateString);
-        return date.toLocaleDateString();
+        const month = date.toLocaleString('en-GB', { month: 'long' });
+        const year = date.getFullYear();
+        const day = date.getDate();
+        return `${year} ${month} ${day}`;
     };
 
     return (

--- a/src/features/inventory/batches/ProductBatchPanel.tsx
+++ b/src/features/inventory/batches/ProductBatchPanel.tsx
@@ -75,7 +75,7 @@ export default function ProductBatchPanel({ open, onClose, productId, onEditBatc
         const month = date.toLocaleString('en-GB', { month: 'long' });
         const year = date.getFullYear();
         const day = date.getDate();
-        return `${year} ${month} ${day}`;
+        return `${year} ${month} ${day}.`;
     };
 
     return (

--- a/src/features/supplies/batches/SupplyBatchPanel.tsx
+++ b/src/features/supplies/batches/SupplyBatchPanel.tsx
@@ -28,7 +28,7 @@ const formatDate = (dateString: string) => {
     const year = date.getFullYear();
     const day = date.getDate();
 
-    return `${year} ${month} ${day}`;
+    return `${year} ${month} ${day}.`;
 };
 
 export default function SupplyBatchDialog({ open, onClose, supplyId }: SupplyBatchDialogProps) {

--- a/src/features/supplies/batches/SupplyBatchPanel.tsx
+++ b/src/features/supplies/batches/SupplyBatchPanel.tsx
@@ -28,7 +28,7 @@ const formatDate = (dateString: string) => {
     const year = date.getFullYear();
     const day = date.getDate();
 
-    return `${year} ${month} ${day}.`;
+    return `${year} ${month} ${day}`;
 };
 
 export default function SupplyBatchDialog({ open, onClose, supplyId }: SupplyBatchDialogProps) {


### PR DESCRIPTION
## Summary
- filter already added batches when selecting supply batches
- ensure editing batches also filters duplicate supply-batch combos

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685311a05cd083289794f8e820cdff01