### PR TITLE
Enable automatic refresh for item lists

### DIFF
--- a/src/features/categories/add/AddCategoryDialog.tsx
+++ b/src/features/categories/add/AddCategoryDialog.tsx
@@ -3,6 +3,7 @@
 import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useToast } from '../../../components/Toast/toast';
 
 type Props = {
@@ -13,6 +14,7 @@ type Props = {
 export function AddCategoryDialog({ open, onClose }: Props) {
     const [categoryName, setCategoryName] = useState('');
     const toast = useToast();
+    const router = useRouter();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -27,6 +29,7 @@ export function AddCategoryDialog({ open, onClose }: Props) {
 
         if (result.success) {
             toast('✅ Category created!');
+            router.refresh();
             onClose();
         } else {
             toast(`Error: ${result.error}`);

--- a/src/features/categories/delete/DeleteButton.tsx
+++ b/src/features/categories/delete/DeleteButton.tsx
@@ -3,6 +3,7 @@
 import { IconButton } from '../../../components/IconButton/iconButton';
 import { useToast } from '../../../components/Toast/toast';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { DeleteConfirmationDialog } from './DeleteConfirmationDialog';
 
 type Props = {
@@ -13,12 +14,14 @@ type Props = {
 export const DeleteButton = ({ categoryId, categoryName }: Props) => {
     const [open, setOpen] = useState(false);
     const toast = useToast();
+    const router = useRouter();
 
     const handleDelete = async () => {
         try {
             const res = await fetch(`/api/categories/deleteCategory?id=${categoryId}`, { method: 'DELETE' });
             if (res.ok) {
                 toast('✅ Category successfully deleted');
+                router.refresh();
             } else {
                 toast('🚫 Failed to delete category');
             }

--- a/src/features/categories/edit/EditCategoryDialog.tsx
+++ b/src/features/categories/edit/EditCategoryDialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useToast } from '../../../components/Toast/toast';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type EditCategoryDialogProps = {
     id: string;
@@ -15,6 +16,7 @@ type EditCategoryDialogProps = {
 export function EditCategoryDialog({ id, currentName, open, onClose }: EditCategoryDialogProps) {
     const [categoryName, setCategoryName] = useState(currentName);
     const toast = useToast();
+    const router = useRouter();
 
     useEffect(() => {
         if (open) {
@@ -40,6 +42,7 @@ export function EditCategoryDialog({ id, currentName, open, onClose }: EditCateg
 
         if (result.success) {
             toast('✅ Category updated!');
+            router.refresh();
             onClose();
         } else {
             toast(`Error: ${result.error}`);

--- a/src/features/inventory/add/AddProductDialog.tsx
+++ b/src/features/inventory/add/AddProductDialog.tsx
@@ -6,6 +6,7 @@ import { Dialog } from '../../../components/Dialog/dialog';
 import { IconButton } from '../../../components/IconButton/iconButton';
 import { useToast } from '../../../components/Toast/toast';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type Category = {
     id: string;
@@ -45,6 +46,7 @@ export function AddProductDialog({ open, onClose, categories = [], variants = []
 
     const [submitting, setSubmitting] = useState(false);
     const toast = useToast();
+    const router = useRouter();
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
@@ -91,6 +93,7 @@ export function AddProductDialog({ open, onClose, categories = [], variants = []
             }
 
             toast('✅ Product created successfully!');
+            router.refresh();
             onClose();
             setFormData({
                 productName: '',

--- a/src/features/inventory/delete/DeleteProductButton.tsx
+++ b/src/features/inventory/delete/DeleteProductButton.tsx
@@ -4,6 +4,7 @@ import { IconButton } from '../../../components/IconButton/iconButton';
 import { useToast } from '../../../components/Toast/toast';
 import { DeleteConfirmationDialog } from './DeleteConfirmationDialog';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type Props = {
     productId: string;
@@ -14,6 +15,7 @@ type Props = {
 export const DeleteProductButton = ({ productId, productName, inventoryId }: Props) => {
     const [open, setOpen] = useState(false);
     const toast = useToast();
+    const router = useRouter();
 
     const handleDelete = async () => {
         try {
@@ -23,6 +25,7 @@ export const DeleteProductButton = ({ productId, productName, inventoryId }: Pro
             );
             if (res.ok) {
                 toast('✅ Product successfully deleted');
+                router.refresh();
             } else {
                 toast('🚫 Failed to delete product');
             }

--- a/src/features/inventory/edit/EditProductDialog.tsx
+++ b/src/features/inventory/edit/EditProductDialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useToast } from '../../../components/Toast/toast';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type Category = {
     id: string;
@@ -59,6 +60,7 @@ export function EditProductDialog({
 }: EditProductDialogProps) {
     const toast = useToast();
     const [submitting, setSubmitting] = useState(false);
+    const router = useRouter();
 
     // Initialize selected inventory with current inventory or first available
     const [selectedInventoryId, setSelectedInventoryId] = useState(
@@ -167,6 +169,7 @@ export function EditProductDialog({
             }
 
             toast('✅ Product updated successfully!');
+            router.refresh();
             onClose();
             if (onSuccess) onSuccess();
         } catch (error: unknown) {

--- a/src/features/supplies/add/AddSupplyDialog.tsx
+++ b/src/features/supplies/add/AddSupplyDialog.tsx
@@ -3,6 +3,7 @@
 import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useToast } from '../../../components/Toast/toast';
 
 type Props = {
@@ -14,6 +15,7 @@ export function AddSupplyDialog({ open, onClose }: Props) {
     const [supplyName, setSupplyName] = useState('');
     const [supplyCategory, setsupplyCategory] = useState('');
     const toast = useToast();
+    const router = useRouter();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -28,6 +30,7 @@ export function AddSupplyDialog({ open, onClose }: Props) {
 
         if (result.success) {
             toast('✅ Supply created!');
+            router.refresh();
             onClose();
         } else {
             toast(`Error: ${result.error}`);

--- a/src/features/supplies/delete/DeleteButton.tsx
+++ b/src/features/supplies/delete/DeleteButton.tsx
@@ -3,6 +3,7 @@
 import { IconButton } from '../../../components/IconButton/iconButton';
 import { useToast } from '../../../components/Toast/toast';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { DeleteConfirmationDialog } from './DeleteConfirmationDialog';
 
 type Props = {
@@ -13,12 +14,14 @@ type Props = {
 export const DeleteButton = ({ supplyId, supplyName }: Props) => {
     const [open, setOpen] = useState(false);
     const toast = useToast();
+    const router = useRouter();
 
     const handleDelete = async () => {
         try {
             const res = await fetch(`/api/supplies/deleteSupply?id=${supplyId}`, { method: 'DELETE' });
             if (res.ok) {
                 toast('✅ Supply successfully deleted');
+                router.refresh();
             } else {
                 toast('🚫 Failed to delete supply');
             }

--- a/src/features/supplies/edit/EditSupplyDialog.tsx
+++ b/src/features/supplies/edit/EditSupplyDialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useToast } from '../../../components/Toast/toast';
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 type EditSupplyDialogProps = {
     id: string;
@@ -17,6 +18,7 @@ export function EditSupplyDialog({ id, currentName, currentCategory, open, onClo
     const [supplyName, setSupplyName] = useState(currentName);
     const [supplyCategory, setSupplyCategory] = useState(currentCategory);
     const toast = useToast();
+    const router = useRouter();
 
     useEffect(() => {
         if (open) {
@@ -44,6 +46,7 @@ export function EditSupplyDialog({ id, currentName, currentCategory, open, onClo
 
         if (result.success) {
             toast('✅ Supply updated!');
+            router.refresh();
             onClose();
         } else {
             toast(`Error: ${result.error}`);

--- a/src/features/variants/add/AddVariantDialog.tsx
+++ b/src/features/variants/add/AddVariantDialog.tsx
@@ -3,6 +3,7 @@
 import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useToast } from '../../../components/Toast/toast';
 
 type Props = {
@@ -13,6 +14,7 @@ type Props = {
 export function AddVariantDialog({ open, onClose }: Props) {
     const [variantName, setVariantName] = useState('');
     const toast = useToast();
+    const router = useRouter();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -27,6 +29,7 @@ export function AddVariantDialog({ open, onClose }: Props) {
 
         if (result.success) {
             toast('✅ Variant created!');
+            router.refresh();
             onClose();
         } else {
             toast(`Error: ${result.error}`);

--- a/src/features/variants/delete/DeleteButton.tsx
+++ b/src/features/variants/delete/DeleteButton.tsx
@@ -3,6 +3,7 @@
 import { IconButton } from '../../../components/IconButton/iconButton';
 import { useToast } from '../../../components/Toast/toast';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { DeleteConfirmationDialog } from './DeleteConfirmationDialog';
 
 type Props = {
@@ -13,12 +14,14 @@ type Props = {
 export const DeleteButton = ({ variantId, variantName }: Props) => {
     const [open, setOpen] = useState(false);
     const toast = useToast();
+    const router = useRouter();
 
     const handleDelete = async () => {
         try {
             const res = await fetch(`/api/variants/deleteVariant?id=${variantId}`, { method: 'DELETE' });
             if (res.ok) {
                 toast('✅ Variant successfully deleted');
+                router.refresh();
             } else {
                 toast('🚫 Failed to delete variant');
             }

--- a/src/features/variants/edit/EditVariantDialog.tsx
+++ b/src/features/variants/edit/EditVariantDialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../components/Button/button';
 import { Dialog } from '../../../components/Dialog/dialog';
 import { useToast } from '../../../components/Toast/toast';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type EditVariantDialogProps = {
     id: string;
@@ -15,6 +16,7 @@ type EditVariantDialogProps = {
 export function EditVariantDialog({ id, currentName, open, onClose }: EditVariantDialogProps) {
     const [variantName, setVariantName] = useState(currentName);
     const toast = useToast();
+    const router = useRouter();
 
     useEffect(() => {
         if (open) {
@@ -40,6 +42,7 @@ export function EditVariantDialog({ id, currentName, open, onClose }: EditVarian
 
         if (result.success) {
             toast('✅ Variant updated!');
+            router.refresh();
             onClose();
         } else {
             toast(`Error: ${result.error}`);


### PR DESCRIPTION
## Summary
- refresh product, category, variant and supply pages after add/delete/edit actions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bfca80608328866863b87429b344