### PR TITLE
Convert add/edit dialogs to side panels

### DIFF
--- a/src/features/categories/add/AddCategoryDialog.tsx
+++ b/src/features/categories/add/AddCategoryDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '../../../components/Toast/toast';
@@ -37,7 +37,9 @@ export function AddCategoryDialog({ open, onClose }: Props) {
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Add new category">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Add new category">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -49,6 +51,7 @@ export function AddCategoryDialog({ open, onClose }: Props) {
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/categories/edit/EditCategoryDialog.tsx
+++ b/src/features/categories/edit/EditCategoryDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useToast } from '../../../components/Toast/toast';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -50,7 +50,9 @@ export function EditCategoryDialog({ id, currentName, open, onClose }: EditCateg
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Edit category">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Edit category">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -66,6 +68,7 @@ export function EditCategoryDialog({ id, currentName, open, onClose }: EditCateg
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/inventory/add/AddProductDialog.tsx
+++ b/src/features/inventory/add/AddProductDialog.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '../../../components/Button/button';
 import { CgMathPlus } from 'react-icons/cg';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { IconButton } from '../../../components/IconButton/iconButton';
 import { useToast } from '../../../components/Toast/toast';
 import { useState } from 'react';
@@ -112,7 +112,9 @@ export function AddProductDialog({ open, onClose, categories = [], variants = []
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Add new product" size="md">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Add new product">
             <form onSubmit={handleSubmit} className="dialog-form">
                 <div className="input-group">
                     <label htmlFor="productName" className="input-label">Product name</label>
@@ -185,6 +187,7 @@ export function AddProductDialog({ open, onClose, categories = [], variants = []
                     <Button type="submit" variant="primary" disabled={submitting}>Add product</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/inventory/edit/EditProductDialog.tsx
+++ b/src/features/inventory/edit/EditProductDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useToast } from '../../../components/Toast/toast';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -185,7 +185,9 @@ export function EditProductDialog({
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Edit product">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Edit product">
             <form onSubmit={handleSubmit} className="dialog-form">
                 <div className="input-group">
                     <label htmlFor="product_name" className="input-label">
@@ -270,6 +272,7 @@ export function EditProductDialog({
                     <Button type="submit" variant="primary" disabled={submitting}>Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/supplies/add/AddSupplyDialog.tsx
+++ b/src/features/supplies/add/AddSupplyDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '../../../components/Toast/toast';
@@ -57,7 +57,9 @@ export function AddSupplyDialog({ open, onClose }: Props) {
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Add new supply">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Add new supply">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -79,6 +81,7 @@ export function AddSupplyDialog({ open, onClose }: Props) {
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/supplies/batches/AddBatchDialog.tsx
+++ b/src/features/supplies/batches/AddBatchDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Dialog } from '@/src/components/Dialog/dialog';
+import { Panel } from '@/src/components/Panel/panel';
 import { Button } from '@/src/components/Button/button';
 import { useToast } from '../../../components/Toast/toast';
 
@@ -54,7 +54,9 @@ export default function CreateBatchDialog({ open, onClose, supplyId, supplyName,
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Create new batch">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Create new batch">
             <form onSubmit={handleSubmit} className="form-grid">
                 <div className="input-group">
                     <label className="input-label">Supply name</label>
@@ -101,6 +103,7 @@ export default function CreateBatchDialog({ open, onClose, supplyId, supplyName,
                     <Button type="submit" variant="primary" disabled={submitting}>Create batch</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/supplies/batches/EditBatchDialog.tsx
+++ b/src/features/supplies/batches/EditBatchDialog.tsx
@@ -1,5 +1,5 @@
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '@/src/components/Dialog/dialog';
+import { Panel } from '@/src/components/Panel/panel';
 import { useState } from 'react';
 import { useToast } from '../../../components/Toast/toast';
 
@@ -46,7 +46,9 @@ export default function EditBatchDialog({ open, onClose, batch, onUpdated }: Edi
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Edit batch">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Edit batch">
             <form onSubmit={handleSubmit} className="form-grid">
                 <div className="input-group">
                     <label className="input-label">Batch name</label>
@@ -88,6 +90,7 @@ export default function EditBatchDialog({ open, onClose, batch, onUpdated }: Edi
                     <Button type="button" variant="primary" onClick={handleSubmit}>Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/supplies/edit/EditSupplyDialog.tsx
+++ b/src/features/supplies/edit/EditSupplyDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useToast } from '../../../components/Toast/toast';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
@@ -67,7 +67,9 @@ export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onC
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Edit supply">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Edit supply">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -89,6 +91,7 @@ export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onC
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/supplyCategories/add/AddSupplyCategoryDialog.tsx
+++ b/src/features/supplyCategories/add/AddSupplyCategoryDialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/src/components/Button/button';
-import { Dialog } from '@/src/components/Dialog/dialog';
+import { Panel } from '@/src/components/Panel/panel';
 import { useToast } from '@/src/components/Toast/toast';
 
 type Props = {
@@ -39,7 +39,9 @@ export function AddSupplyCategoryDialog({ open, onClose, onAdded }: Props) {
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Add supply category">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Add supply category">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -50,6 +52,7 @@ export function AddSupplyCategoryDialog({ open, onClose, onAdded }: Props) {
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/supplyCategories/edit/EditSupplyCategoryDialog.tsx
+++ b/src/features/supplyCategories/edit/EditSupplyCategoryDialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/src/components/Button/button';
-import { Dialog } from '@/src/components/Dialog/dialog';
+import { Panel } from '@/src/components/Panel/panel';
 import { useToast } from '@/src/components/Toast/toast';
 
 type Props = {
@@ -42,7 +42,9 @@ export function EditSupplyCategoryDialog({ id, currentName, open, onClose, onUpd
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Edit category">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Edit category">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -53,6 +55,7 @@ export function EditSupplyCategoryDialog({ id, currentName, open, onClose, onUpd
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/variants/add/AddVariantDialog.tsx
+++ b/src/features/variants/add/AddVariantDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '../../../components/Toast/toast';
@@ -37,7 +37,9 @@ export function AddVariantDialog({ open, onClose }: Props) {
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Add new variant">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Add new variant">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -49,6 +51,7 @@ export function AddVariantDialog({ open, onClose }: Props) {
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }

--- a/src/features/variants/edit/EditVariantDialog.tsx
+++ b/src/features/variants/edit/EditVariantDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '../../../components/Button/button';
-import { Dialog } from '../../../components/Dialog/dialog';
+import { Panel } from '../../../components/Panel/panel';
 import { useToast } from '../../../components/Toast/toast';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -50,7 +50,9 @@ export function EditVariantDialog({ id, currentName, open, onClose }: EditVarian
     };
 
     return (
-        <Dialog open={open} onClose={onClose} title="Edit variant">
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <Panel isOpen={open} onClose={onClose} title="Edit variant">
             <form onSubmit={handleSubmit} method="dialog">
                 <div className="input-group">
                     <label className="input-label">Name</label>
@@ -66,6 +68,7 @@ export function EditVariantDialog({ id, currentName, open, onClose }: EditVarian
                     <Button variant="primary" type="submit">Save</Button>
                 </div>
             </form>
-        </Dialog>
+            </Panel>
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- replace Dialog component usage in all Add/Edit screens with Panel
- show backdrop behind these new side panels

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641edf43448328b3ebf27f58b963ae