### PR TITLE
Fix unused variable lint error

### DIFF
--- a/src/app/api/supplies/route.ts
+++ b/src/app/api/supplies/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
 
   const supplies = (data || []).map((row: any) => {
     if ('supply_batch' in row) {
-      const { supply_batch, ...rest } = row;
+      const { supply_batch: _unused, ...rest } = row;
       return rest;
     }
     return row;


### PR DESCRIPTION
## Summary
- fix unused variable lint error in supplies API handler

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865565626648328aec5e51eebd9a751