### PR TITLE
Expand sidebar inventory list

### DIFF
--- a/src/app/api/inventories/route.ts
+++ b/src/app/api/inventories/route.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@/src/utils/supabase/server';
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('inventories')
+    .select('id, inventory_name')
+    .order('inventory_name');
+
+  if (error) {
+    console.error('Error fetching inventories:', error);
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+  }
+
+  return new Response(JSON.stringify({ inventories: data }), { status: 200 });
+}

--- a/src/app/api/inventories/route.ts
+++ b/src/app/api/inventories/route.ts
@@ -2,9 +2,20 @@ import { createClient } from '@/src/utils/supabase/server';
 
 export async function GET() {
   const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+    });
+  }
   const { data, error } = await supabase
     .from('inventories')
     .select('id, inventory_name')
+    .eq('owner_id', user.id)
     .order('inventory_name');
 
   if (error) {

--- a/src/app/api/inventory/updateInventoryItem/route.ts
+++ b/src/app/api/inventory/updateInventoryItem/route.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@/src/utils/supabase/server';
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const body = await request.json();
+  const { product_id, inventory_id, product_sku, product_quantity } = body;
+
+  if (!product_id || !inventory_id) {
+    return new Response(JSON.stringify({ success: false, error: 'Missing identifiers' }), { status: 400 });
+  }
+
+  try {
+    const { error } = await supabase
+      .from('product_inventories')
+      .upsert({
+        product_id,
+        inventory_id,
+        product_sku: product_sku || null,
+        product_quantity: product_quantity ?? 0,
+        owner_id: user.id,
+      }, { onConflict: 'product_id, inventory_id' });
+
+    if (error) throw error;
+
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  } catch (error: unknown) {
+    console.error('Error updating inventory item:', error);
+    const message = error instanceof Error ? error.message : 'Failed to update';
+    return new Response(JSON.stringify({ success: false, error: message }), { status: 500 });
+  }
+}

--- a/src/app/api/inventory/updateProductInventories/route.ts
+++ b/src/app/api/inventory/updateProductInventories/route.ts
@@ -9,7 +9,7 @@ export async function PUT(request: Request) {
   }
 
   const body = await request.json();
-  const { id, product_name, product_category, product_status, inventories } = body;
+  const { id, product_name, product_category, product_variant, product_status, inventories } = body;
 
   if (!product_name?.trim()) {
     return new Response(JSON.stringify({ success: false, error: 'Product name is required' }), { status: 400 });
@@ -36,6 +36,7 @@ export async function PUT(request: Request) {
       .update({
         product_name,
         product_category: product_category || null,
+        product_variant: product_variant || null,
         product_status: product_status || false,
       })
       .eq('id', id)

--- a/src/app/api/products/addNewProduct/route.ts
+++ b/src/app/api/products/addNewProduct/route.ts
@@ -16,6 +16,7 @@ export async function POST(request: Request) {
         const {
             product_name,
             product_category,
+            product_variant,
             product_status,
             inventories
         } = body;
@@ -39,8 +40,9 @@ export async function POST(request: Request) {
             .insert([{
                 product_name,
                 product_category,
+                product_variant,
                 product_status,
-                owner_id: user.id
+                    owner_id: user.id
             }])
             .select()
             .single();

--- a/src/app/inventory/[inventory]/page.tsx
+++ b/src/app/inventory/[inventory]/page.tsx
@@ -1,0 +1,6 @@
+import InventoryPage from '../page';
+
+export default function InventorySlugPage({ params, searchParams }: { params: { inventory: string }; searchParams: any }) {
+    const merged = { ...searchParams, inventory: params.inventory };
+    return <InventoryPage searchParams={Promise.resolve(merged)} />;
+}

--- a/src/app/inventory/[inventory]/page.tsx
+++ b/src/app/inventory/[inventory]/page.tsx
@@ -1,6 +1,6 @@
 import InventoryPage from '../page';
 
-export default function InventorySlugPage({ params, searchParams }: { params: { inventory: string }; searchParams: any }) {
+export default async function InventorySlugPage({ params, searchParams }: { params: { inventory: string }; searchParams: any }) {
     const merged = { ...searchParams, inventory: params.inventory };
     return <InventoryPage searchParams={Promise.resolve(merged)} />;
 }

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,6 +1,6 @@
 import { DeleteProductButton } from '@/src/features/products/delete/DeleteProductButton';
 import { FilterBar } from '@/src/features/inventory/FilterBar';
-import { EditProductButton } from '@/src/features/products/edit/EditProductButton';
+import { EditInventoryItemButton } from '@/src/features/inventory/edit/EditInventoryItemButton';
 import { Pagination } from '@/src/components/Pagination/pagination';
 import { createClient } from '@/src/utils/supabase/server';
 import { slugify } from '@/src/utils/slugify';
@@ -227,15 +227,13 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                     <td>{(product.categories as any)?.category_name || '-'}</td>
                                     <td>{(inventoryInfo as any)?.variants?.variant_name || '-'}</td>
                                     <td className="table-actions">
-                                        <EditProductButton
-                                            id={product.id}
-                                            product_name={product.product_name || ''}
-                                            product_category={product.product_category || ''}
-                                            product_status={product.product_status || false}
-                                            categories={categories || []}
-                                            inventories={inventories}
-                                            currentInventoryId={inventoryId.toString()}
-                                            productInventories={[]}
+                                        <EditInventoryItemButton
+                                            productId={product.id}
+                                            inventoryId={inventoryId.toString()}
+                                            productName={product.product_name || ''}
+                                            productCategoryName={(product.categories as any)?.category_name || ''}
+                                            productSku={inventoryInfo?.product_sku || ''}
+                                            productQuantity={inventoryInfo?.product_quantity ?? 0}
                                         />
                                         <DeleteProductButton
                                             productId={product.id}

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -21,12 +21,12 @@ const validStockFilters = ['all', 'low', 'out', 'in'] as const;
 type StockFilter = (typeof validStockFilters)[number];
 
 function isStockFilter(value: unknown): value is StockFilter {
-  return typeof value === 'string' && validStockFilters.includes(value as StockFilter);
+    return typeof value === 'string' && validStockFilters.includes(value as StockFilter);
 }
 
 const PAGE_SIZE = 10;
 
-export default async function Home({ searchParams}: {searchParams: Promise<SearchParams>}) {
+export default async function Home({ searchParams }: { searchParams: Promise<SearchParams> }) {
     const supabase = await createClient();
     const resolvedSearchParams = await searchParams;
 
@@ -55,7 +55,6 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
             </main>
         );
     }
-
     inventories.sort((a, b) => {
         if (a.is_default && !b.is_default) return -1;
         if (!a.is_default && b.is_default) return 1;
@@ -69,7 +68,6 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
     if (!selectedInventory) {
         selectedInventory = inventories.find((inv) => inv.is_default) || inventories[0];
     }
-
     const inventoryId = selectedInventory?.id;
 
     if (!inventoryId) {
@@ -186,7 +184,10 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
         <main className="inventory-page">
             {/* Header Section */}
             <div className="pageHeader">
-                <h2 className="heading-title">Inventory</h2>
+                <div>
+                    <h2 className="heading-title">Inventory</h2>
+                    <h3 className="heading-subtitle">{selectedInventory?.inventory_name}</h3>
+                </div>
             </div>
 
             {/* Main Content */}
@@ -220,7 +221,7 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                         <span className="item-sku">{inventoryInfo?.product_sku || '-'}</span>
                                     </td>
                                     <td>
-                                        <div className={`quantity-badge ${inventoryInfo?.product_quantity === 0 ? 'out-of-stock': inventoryInfo?.product_quantity <= 5 ? 'low-stock': ''}`}>
+                                        <div className={`quantity-badge ${inventoryInfo?.product_quantity === 0 ? 'out-of-stock' : inventoryInfo?.product_quantity <= 5 ? 'low-stock' : ''}`}>
                                             {inventoryInfo?.product_quantity ?? '-'}
                                         </div>
                                     </td>

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,7 +1,6 @@
 import { DeleteProductButton } from '@/src/features/products/delete/DeleteProductButton';
 import { FilterBar } from '@/src/features/inventory/FilterBar';
-import { ViewBatchButton } from '@/src/features/products/batches/ViewBatchButton';
-import { InventoryTabs } from '@/src/features/inventory/InventoryTabs';
+import { EditProductButton } from '@/src/features/products/edit/EditProductButton';
 import { Pagination } from '@/src/components/Pagination/pagination';
 import { createClient } from '@/src/utils/supabase/server';
 import { slugify } from '@/src/utils/slugify';
@@ -11,7 +10,6 @@ type SearchParams = {
     query?: string;
     page?: string;
     inventory?: string;
-    tab?: string;
     statusFilter?: 'active' | 'inactive' | 'all';
     categoryFilter?: string;
     variantFilter?: string;
@@ -43,7 +41,6 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
     const page = Math.max(1, parseInt(resolvedSearchParams.page || '1'));
     const query = resolvedSearchParams.query || '';
     const inventorySlug = resolvedSearchParams.inventory;
-    const tab = resolvedSearchParams.tab || 'active';
 
     // ========== INVENTORY FETCHING & PROCESSING ==========
     const { data: inventories } = await supabase
@@ -192,9 +189,6 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                 <h2 className="heading-title">Inventory</h2>
             </div>
 
-            {/* Inventory Tabs */}
-            <InventoryTabs inventories={inventories} selectedInventory={selectedInventory} tab={tab}/>
-
             {/* Main Content */}
             <div className="content inventory-content">
                 <FilterBar
@@ -211,9 +205,9 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                         <tr>
                             <th>Product name & SKU</th>
                             <th>Quantity</th>
-                            <th>Category</th>
-                            <th>Variant</th>
-                            <th></th>
+                            <th>Product category</th>
+                            <th>Product variant</th>
+                            <th>Edit / Delete</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -232,12 +226,22 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                     </td>
                                     <td>{(product.categories as any)?.category_name || '-'}</td>
                                     <td>{(product.variants as any)?.variant_name || '-'}</td>
-                                    <td>
-                                        <div className="table-actions">
-                                            <DeleteProductButton productId={product.id} productName={product.product_name} inventoryId={inventoryId}/>
-                                            <ViewBatchButton productId={product.id} />
-
-                                        </div>
+                                    <td className="table-actions">
+                                        <EditProductButton
+                                            id={product.id}
+                                            product_name={product.product_name || ''}
+                                            product_category={product.product_category || ''}
+                                            product_status={product.product_status || false}
+                                            categories={categories || []}
+                                            inventories={inventories}
+                                            currentInventoryId={inventoryId.toString()}
+                                            productInventories={[]}
+                                        />
+                                        <DeleteProductButton
+                                            productId={product.id}
+                                            productName={product.product_name}
+                                            inventoryId={inventoryId}
+                                        />
                                     </td>
                                 </tr>
                             );

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -205,9 +205,9 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                         <tr>
                             <th>Product name & SKU</th>
                             <th>Quantity</th>
-                            <th>Product category</th>
-                            <th>Product variant</th>
-                            <th>Edit / Delete</th>
+                            <th>Category</th>
+                            <th>Variant</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -227,6 +227,12 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                     <td>{(product.categories as any)?.category_name || '-'}</td>
                                     <td>{(product.variants as any)?.variant_name || '-'}</td>
                                     <td className="table-actions">
+                                        <DeleteProductButton
+                                            productId={product.id}
+                                            productName={product.product_name}
+                                            inventoryId={inventoryId}
+                                        />
+
                                         <EditInventoryItemButton
                                             productId={product.id}
                                             inventoryId={inventoryId.toString()}
@@ -234,11 +240,6 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                             productCategoryName={(product.categories as any)?.category_name || ''}
                                             productSku={inventoryInfo?.product_sku || ''}
                                             productQuantity={inventoryInfo?.product_quantity ?? 0}
-                                        />
-                                        <DeleteProductButton
-                                            productId={product.id}
-                                            productName={product.product_name}
-                                            inventoryId={inventoryId}
                                         />
                                     </td>
                                 </tr>

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -59,8 +59,13 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
         .select('id, category_name')
         .order('category_name');
 
-    const [{ data: productInventories }, { data: categories }] =
-        await Promise.all([productInventoriesPromise, categoriesPromise]);
+    const variantsPromise = supabase
+        .from('variants')
+        .select('id, variant_name')
+        .order('variant_name');
+
+    const [{ data: productInventories }, { data: categories }, { data: variants }] =
+        await Promise.all([productInventoriesPromise, categoriesPromise, variantsPromise]);
 
     // Build main products query
     let productsQuery = supabase
@@ -69,8 +74,10 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
             id,
             product_name,
             product_category,
+            product_variant,
             product_status,
-            categories(id, category_name)
+            categories(id, category_name),
+            variants(id, variant_name)
         `)
         .order('product_name', { ascending: true });
 
@@ -122,7 +129,7 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
             {/* Header Section */}
             <div className="pageHeader">
                 <h2 className="heading-title">Products</h2>
-                <AddButton categories={categories || []} inventories={inventories}/>
+                <AddButton categories={categories || []} variants={variants || []} inventories={inventories}/>
             </div>
 
             {/* Main Content */}
@@ -138,6 +145,7 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                         <tr>
                             <th>Product name</th>
                             <th>Category</th>
+                            <th>Variant</th>
                             <th>Inventories</th>
                             <th>Status</th>
                             <th></th>
@@ -151,6 +159,7 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                         <span className="item-name">{product.product_name}</span>
                                     </td>
                                     <td>{(product.categories as any)?.category_name || '-'}</td>
+                                    <td>{(product.variants as any)?.variant_name || '-'}</td>
                                     <td>
                                         <div className="badge">
                                             {(inventoryNamesMap.get(product.id) || []).join(', ') || '-'}
@@ -166,8 +175,10 @@ export default async function Home({ searchParams}: {searchParams: Promise<Searc
                                                 id={product.id}
                                                 product_name={product.product_name || ''}
                                                 product_category={product.product_category || ''}
+                                                product_variant={product.product_variant || ''}
                                                 product_status={product.product_status || false}
                                                 categories={categories || []}
+                                                variants={variants || []}
                                                 inventories={inventories}
                                                 currentInventoryId=""
                                                 productInventories={productInventories || []}

--- a/src/app/products/products.module.css
+++ b/src/app/products/products.module.css
@@ -1,0 +1,13 @@
+.badge {
+    background-color: #b795c2;
+    border-radius: 0.25rem;
+    color: #fff;
+    display: inline-block;
+    font-size: 0.75em;
+    font-weight: 600;
+    padding: 0.25em 0.5em;
+
+    &:not(:last-child) {
+        margin-right: 0.5em;
+    }
+}

--- a/src/components/Sidebar/sidebar.module.css
+++ b/src/components/Sidebar/sidebar.module.css
@@ -49,15 +49,16 @@
 }
 
 button.navigationLink {
+    background-color: transparent;
     border: 0 none;
     cursor: pointer;
     font-family: "Quicksand", "Quicksand Fallback";
     font-size: 1rem;
     height: 40px !important;
+}
 
-    & .fa-chevron-down {
-        font-size: .875rem;
-    }
+.chevron {
+    font-size: .875rem;
 }
 
 .navigation {

--- a/src/components/Sidebar/sidebar.module.css
+++ b/src/components/Sidebar/sidebar.module.css
@@ -76,3 +76,26 @@
         background: rgba(176, 136, 189, 0.30);
     }
 }
+
+.subMenu {
+    list-style: none;
+    margin: 0.5rem 0 0 1.5rem;
+    padding: 0;
+}
+
+.subLink {
+    color: #957D9D;
+    display: block;
+    font-weight: 700;
+    padding: 0.25rem 0.5rem;
+    text-decoration: none;
+    border-radius: 4px;
+    margin-bottom: 0.25rem;
+
+    &.active,
+    &:hover {
+        background-color: #fff;
+        box-shadow: 0px 2px 4px 0px rgba(162, 166, 187, 0.50);
+        color: #725A79;
+    }
+}

--- a/src/components/Sidebar/sidebar.module.css
+++ b/src/components/Sidebar/sidebar.module.css
@@ -36,11 +36,27 @@
         }
     }
 
-    &.collapsed {        
+    &.collapsed {
         & .navigationLink {
             justify-content: center;
             width: 1.5rem;
         }
+
+        & button.navigationLink {
+            width: auto;
+        }
+    }
+}
+
+button.navigationLink {
+    border: 0 none;
+    cursor: pointer;
+    font-family: "Quicksand", "Quicksand Fallback";
+    font-size: 1rem;
+    height: 40px !important;
+
+    & .fa-chevron-down {
+        font-size: .875rem;
     }
 }
 
@@ -58,7 +74,7 @@
 }
 
 .button {
-    background-color:#fff;
+    background-color: #fff;
     border: 0;
     border-radius: .5rem;
     color: #725A79;
@@ -69,33 +85,31 @@
     width: fit-content;
 
     &:hover {
-        background: rgba(176, 136, 189, 0.20);
+        background-color: rgba(176, 136, 189, 0.20);
     }
 
     &:active {
-        background: rgba(176, 136, 189, 0.30);
+        background-color: rgba(176, 136, 189, 0.30);
     }
 }
 
 .subMenu {
     list-style: none;
-    margin: 0.5rem 0 0 1.5rem;
+    margin: 0.5rem 0 1rem 1.5rem;
     padding: 0;
 }
 
 .subLink {
     color: #957D9D;
     display: block;
-    font-weight: 700;
-    padding: 0.25rem 0.5rem;
+    font-weight: 600;
+    padding: .25rem 0 .25rem 1.2rem;
     text-decoration: none;
-    border-radius: 4px;
     margin-bottom: 0.25rem;
 
     &.active,
     &:hover {
-        background-color: #fff;
-        box-shadow: 0px 2px 4px 0px rgba(162, 166, 187, 0.50);
-        color: #725A79;
+        color: #614968;
+        font-weight: 700;
     }
 }

--- a/src/components/Sidebar/sidebar.tsx
+++ b/src/components/Sidebar/sidebar.tsx
@@ -3,7 +3,6 @@
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from "react";
 import Link from 'next/link';
-import { supabaseClient } from '@/src/utils/supabase/client';
 import { slugify } from '@/src/utils/slugify';
 import styles from "./sidebar.module.css";
 
@@ -15,11 +14,18 @@ const Sidebar = () => {
     const searchParams = useSearchParams();
 
     useEffect(() => {
-        supabaseClient
-            .from('inventories')
-            .select('id, inventory_name')
-            .order('inventory_name')
-            .then(({ data }) => setInventories(data || []));
+        const load = async () => {
+            try {
+                const res = await fetch('/api/inventories');
+                if (res.ok) {
+                    const data = await res.json();
+                    setInventories(data.inventories || []);
+                }
+            } catch (err) {
+                console.error('Failed to load inventories', err);
+            }
+        };
+        load();
     }, []);
 
     return (

--- a/src/components/Sidebar/sidebar.tsx
+++ b/src/components/Sidebar/sidebar.tsx
@@ -41,7 +41,7 @@ const Sidebar = () => {
                             <button type="button" className={`${styles.navigationLink} ${pathname.startsWith('/inventory') ? styles.active : ''}`} onClick={() => setInventoryOpen((prev) => !prev)}>
                                 <i className="fa-solid fa-warehouse"></i>
                                 {!isCollapsed && <span>Inventory</span>}
-                                {!isCollapsed && <i className={`fa-solid ${inventoryOpen ? 'fa-chevron-down' : 'fa-chevron-right'}`}></i>}
+                                {!isCollapsed && <i className={`${styles.chevron} fa-solid ${inventoryOpen ? 'fa-chevron-down' : 'fa-chevron-right'}`}></i>}
                             </button>
                             {!isCollapsed && inventoryOpen && (
                                 <ul className={styles.subMenu}>

--- a/src/components/Sidebar/sidebar.tsx
+++ b/src/components/Sidebar/sidebar.tsx
@@ -1,13 +1,26 @@
 "use client";
 
-import { usePathname } from 'next/navigation';
-import { useState } from "react";
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from "react";
 import Link from 'next/link';
+import { supabaseClient } from '@/src/utils/supabase/client';
+import { slugify } from '@/src/utils/slugify';
 import styles from "./sidebar.module.css";
 
 const Sidebar = () => {
     const [isCollapsed, setIsCollapsed] = useState(false);
+    const [inventoryOpen, setInventoryOpen] = useState(false);
+    const [inventories, setInventories] = useState<{ id: number; inventory_name: string }[]>([]);
     const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        supabaseClient
+            .from('inventories')
+            .select('id, inventory_name')
+            .order('inventory_name')
+            .then(({ data }) => setInventories(data || []));
+    }, []);
 
     return (
         <aside className={`${styles.sidebar} ${isCollapsed ? styles.collapsed : ""}`}>
@@ -19,10 +32,24 @@ const Sidebar = () => {
                 <nav className={styles.navigation}>
                     <ul>
                         <li>
-                            <Link className={`${styles.navigationLink} ${pathname === '/inventory' ? styles.active : ''}`} href="/" title="Inventory">
+                            <button type="button" className={`${styles.navigationLink} ${pathname.startsWith('/inventory') ? styles.active : ''}`} onClick={() => setInventoryOpen((prev) => !prev)}>
                                 <i className="fa-solid fa-warehouse"></i>
                                 {!isCollapsed && <span>Inventory</span>}
-                            </Link>
+                                {!isCollapsed && <i className={`fa-solid ${inventoryOpen ? 'fa-chevron-down' : 'fa-chevron-right'}`}></i>}
+                            </button>
+                            {!isCollapsed && inventoryOpen && (
+                                <ul className={styles.subMenu}>
+                                    {inventories.map(inv => {
+                                        const slug = slugify(inv.inventory_name);
+                                        const isActive = pathname === `/inventory/${slug}` || (pathname === '/inventory' && searchParams.get('inventory') === slug);
+                                        return (
+                                            <li key={inv.id}>
+                                                <Link href={`/inventory/${slug}`} className={`${styles.subLink} ${isActive ? styles.active : ''}`}>{inv.inventory_name}</Link>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            )}
                         </li>
                                                 <li>
                             <Link className={`${styles.navigationLink} ${pathname === '/products' ? styles.active : ''}`} href="/products" title="Products">

--- a/src/features/inventory/InventoryTabs.tsx
+++ b/src/features/inventory/InventoryTabs.tsx
@@ -3,7 +3,6 @@ import { slugify } from '@/src/utils/slugify';
 type Inventory = {
     id: number;
     inventory_name: string;
-    is_default: boolean;
 };
 
 type TabsProps = {

--- a/src/features/inventory/edit/EditInventoryItemButton.tsx
+++ b/src/features/inventory/edit/EditInventoryItemButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+import { IconButton } from '@/src/components/IconButton/iconButton';
+import { EditInventoryItemDialog } from './EditInventoryItemDialog';
+
+export type InventoryItemProps = {
+    productId: string;
+    inventoryId: string;
+    productName: string;
+    productCategoryName: string;
+    productSku: string | null;
+    productQuantity: number | null;
+    onSuccess?: () => void;
+};
+
+export function EditInventoryItemButton({
+    productId,
+    inventoryId,
+    productName,
+    productCategoryName,
+    productSku,
+    productQuantity,
+    onSuccess,
+}: InventoryItemProps) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <IconButton icon={<i className="fa-regular fa-pen-to-square"></i>} onClick={() => setOpen(true)} title="Edit" />
+            {open && (
+                <EditInventoryItemDialog
+                    open={open}
+                    onClose={() => setOpen(false)}
+                    productId={productId}
+                    inventoryId={inventoryId}
+                    productName={productName}
+                    productCategoryName={productCategoryName}
+                    productSku={productSku}
+                    productQuantity={productQuantity}
+                    onSuccess={onSuccess}
+                />
+            )}
+        </>
+    );
+}

--- a/src/features/inventory/edit/EditInventoryItemDialog.tsx
+++ b/src/features/inventory/edit/EditInventoryItemDialog.tsx
@@ -74,7 +74,7 @@ export function EditInventoryItemDialog({
             toast('✅ Inventory item updated!');
             router.refresh();
             onClose();
-            onSuccess && onSuccess();
+            if (onSuccess) onSuccess();
         } catch (error: any) {
             toast(`❌ ${error.message || 'Error updating item'}`);
         } finally {

--- a/src/features/inventory/edit/EditInventoryItemDialog.tsx
+++ b/src/features/inventory/edit/EditInventoryItemDialog.tsx
@@ -100,13 +100,15 @@ export function EditInventoryItemDialog({
                             <label className="input-label">Category</label>
                             <input type="text" value={productCategoryName} disabled className="input-max-width" />
                         </div>
-                        <div className="input-group">
-                            <label className="input-label" htmlFor="sku">SKU</label>
-                            <input id="sku" name="sku" type="text" className="input-max-width" value={formData.sku} onChange={handleChange} />
-                        </div>
-                        <div className="input-group">
-                            <label className="input-label" htmlFor="quantity">Quantity</label>
-                            <input id="quantity" name="quantity" type="number" min="0" className="input-max-width" value={formData.quantity} onChange={handleChange} />
+                        <div className="double-input-group">
+                            <div className="input-group input-grow">
+                                <label className="input-label" htmlFor="sku">SKU</label>
+                                <input id="sku" name="sku" type="text" className="input-max-width" value={formData.sku} onChange={handleChange} />
+                            </div>
+                            <div className="input-group input-shrink">
+                                <label className="input-label" htmlFor="quantity">Quantity</label>
+                                <input id="quantity" name="quantity" type="number" min="0" className="input-max-width" value={formData.quantity} onChange={handleChange} />
+                            </div>
                         </div>
                     </div>
                     <div className="side-panel-footer">

--- a/src/features/inventory/edit/EditInventoryItemDialog.tsx
+++ b/src/features/inventory/edit/EditInventoryItemDialog.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Button } from '@/src/components/Button/button';
+import { IconButton } from '@/src/components/IconButton/iconButton';
+import { useToast } from '@/src/components/Toast/toast';
+import { useRouter } from 'next/navigation';
+
+export type EditInventoryItemDialogProps = {
+    open: boolean;
+    onClose: () => void;
+    productId: string;
+    inventoryId: string;
+    productName: string;
+    productCategoryName: string;
+    productSku: string | null;
+    productQuantity: number | null;
+    onSuccess?: () => void;
+};
+
+export function EditInventoryItemDialog({
+    open,
+    onClose,
+    productId,
+    inventoryId,
+    productName,
+    productCategoryName,
+    productSku,
+    productQuantity,
+    onSuccess,
+}: EditInventoryItemDialogProps) {
+    const [formData, setFormData] = useState({
+        sku: productSku || '',
+        quantity: productQuantity ?? 0,
+    });
+    const [submitting, setSubmitting] = useState(false);
+    const toast = useToast();
+    const router = useRouter();
+    const isMounted = useRef(false);
+    const [isOpen, setIsOpen] = useState(false);
+
+    useEffect(() => {
+        if (open) {
+            isMounted.current = true;
+            setFormData({ sku: productSku || '', quantity: productQuantity ?? 0 });
+            setTimeout(() => setIsOpen(true), 50);
+        } else {
+            setIsOpen(false);
+            isMounted.current = false;
+        }
+    }, [open, productSku, productQuantity]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: name === 'quantity' ? Number(value) : value }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setSubmitting(true);
+        try {
+            const res = await fetch('/api/inventory/updateInventoryItem', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    product_id: productId,
+                    inventory_id: inventoryId,
+                    product_sku: formData.sku,
+                    product_quantity: formData.quantity,
+                }),
+            });
+            const result = await res.json();
+            if (!result.success) throw new Error(result.error || 'Failed to update');
+            toast('✅ Inventory item updated!');
+            router.refresh();
+            onClose();
+            onSuccess && onSuccess();
+        } catch (error: any) {
+            toast(`❌ ${error.message || 'Error updating item'}`);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            {open && <div className="side-panel-backdrop" onClick={onClose} />}
+            <div className={`side-panel side-panel-sm ${isOpen ? 'open' : ''}`} role="dialog" aria-labelledby="dialog-title">
+                <div className="side-panel-header">
+                    <h3 className="side-panel-title" id="dialog-title">Edit inventory item</h3>
+                    <IconButton icon={<i className="fa-solid fa-close"></i>} onClick={onClose} title="Close panel" />
+                </div>
+                <form onSubmit={handleSubmit} className="side-panel-form">
+                    <div className="side-panel-content">
+                        <div className="input-group">
+                            <label className="input-label">Product name</label>
+                            <input type="text" value={productName} disabled className="input-max-width" />
+                        </div>
+                        <div className="input-group">
+                            <label className="input-label">Category</label>
+                            <input type="text" value={productCategoryName} disabled className="input-max-width" />
+                        </div>
+                        <div className="input-group">
+                            <label className="input-label" htmlFor="sku">SKU</label>
+                            <input id="sku" name="sku" type="text" className="input-max-width" value={formData.sku} onChange={handleChange} />
+                        </div>
+                        <div className="input-group">
+                            <label className="input-label" htmlFor="quantity">Quantity</label>
+                            <input id="quantity" name="quantity" type="number" min="0" className="input-max-width" value={formData.quantity} onChange={handleChange} />
+                        </div>
+                    </div>
+                    <div className="side-panel-footer">
+                        <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>Cancel</Button>
+                        <Button type="submit" variant="primary" disabled={submitting}>Save</Button>
+                    </div>
+                </form>
+            </div>
+        </>
+    );
+}

--- a/src/features/products/FilterBar.tsx
+++ b/src/features/products/FilterBar.tsx
@@ -8,13 +8,17 @@ import { Search } from "@/src/components/SearchBar/searchBar";
 type FilterBarProps = {
     statusFilter: "active" | "inactive" | "all";
     categoryFilter: string;
+    variantFilter: string;
     categories: { id: number; category_name: string }[];
+    variants: { id: number; variant_name: string }[];
 };
 
 export function FilterBar({
     statusFilter: initialStatusFilter,
     categoryFilter: initialCategoryFilter,
+    variantFilter: initialVariantFilter,
     categories,
+    variants,
 }: FilterBarProps) {
     const router = useRouter();
     const searchParams = useSearchParams();
@@ -22,13 +26,15 @@ export function FilterBar({
 
     const [statusFilter, setStatusFilter] = useState(initialStatusFilter);
     const [categoryFilter, setCategoryFilter] = useState(initialCategoryFilter);
+    const [variantFilter, setVariantFilter] = useState(initialVariantFilter);
     const [searchQuery, setSearchQuery] = useState(searchParams.get("query") || "");
 
     useEffect(() => {
         setStatusFilter(initialStatusFilter);
         setCategoryFilter(initialCategoryFilter);
+        setVariantFilter(initialVariantFilter);
         setSearchQuery(searchParams.get("query") || "");
-    }, [initialStatusFilter, initialCategoryFilter, searchParams]);
+    }, [initialStatusFilter, initialCategoryFilter, initialVariantFilter, searchParams]);
 
     const updateQueryParam = async (key: string, value: string) => {
         setIsLoading(true);
@@ -73,7 +79,7 @@ export function FilterBar({
     };
 
     const hasActiveFilters = () => {
-        const filterKeys = ["query", "statusFilter", "categoryFilter"];
+        const filterKeys = ["query", "statusFilter", "categoryFilter", "variantFilter"];
         return filterKeys.some(key => searchParams.has(key));
     };
 
@@ -98,6 +104,18 @@ export function FilterBar({
                     {categories.map((c) => (
                         <option key={c.id} value={c.id.toString()}>
                             {c.category_name}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <div>
+                <label htmlFor="variant-filter" className="input-label">Variant</label>
+                <select id="variant-filter" value={variantFilter} onChange={(e) => { setVariantFilter(e.target.value); updateQueryParam("variantFilter", e.target.value); }} disabled={isLoading}>
+                    <option value="all">All</option>
+                    {variants.map((v) => (
+                        <option key={v.id} value={v.id.toString()}>
+                            {v.variant_name}
                         </option>
                     ))}
                 </select>

--- a/src/features/products/add/AddButton.tsx
+++ b/src/features/products/add/AddButton.tsx
@@ -16,13 +16,19 @@ type Inventory = {
     inventory_name: string;
 };
 
+type Variant = {
+    id: string;
+    variant_name: string;
+};
+
 type Props = {
     categories: Category[];
+    variants?: Variant[];
     inventories?: Inventory[];
 };
 
 
-export function AddButton({ categories, inventories }: Props) {
+export function AddButton({ categories, variants, inventories }: Props) {
     const [open, setOpen] = useState(false);
 
     return (
@@ -35,6 +41,7 @@ export function AddButton({ categories, inventories }: Props) {
                     open={open}
                     onClose={() => setOpen(false)}
                     categories={categories}
+                    variants={variants}
                     inventories={inventories ?? []}
                 />
             )}

--- a/src/features/products/add/AddProductDialog.tsx
+++ b/src/features/products/add/AddProductDialog.tsx
@@ -14,7 +14,6 @@ type Category = {
 type Inventory = {
     id: string;
     inventory_name: string;
-    is_default?: boolean;
 };
 
 type Variant = {
@@ -135,7 +134,7 @@ export function AddProductDialog({ open, onClose, categories = [], variants = []
     return (
         <>
             {open && <div className="side-panel-backdrop" onClick={onClose} />}
-            <div className={`side-panel side-panel-md ${isOpen ? 'open' : ''}`} role="dialog" aria-labelledby="dialog-title">
+            <div className={`side-panel side-panel-sm ${isOpen ? 'open' : ''}`} role="dialog" aria-labelledby="dialog-title">
                 <div className="side-panel-header">
                     <h3 className="side-panel-title" id="dialog-title">Add new product</h3>
                     <IconButton icon={<i className="fa-solid fa-close"></i>} onClick={onClose} title="Close panel" />
@@ -176,33 +175,23 @@ export function AddProductDialog({ open, onClose, categories = [], variants = []
                             </label>
                         </div>
 
-                        <div className="boxed-section">
-                            <h3 className="section-subtitle">Inventories</h3>
+                        <h3 className="section-subtitle">Inventories</h3>
 
-                            {inventoryEntries.map((entry, index) => (
-                                <div key={index} className="double-input-group">
-                                    <div>
-                                        <label className="input-label">Inventory name</label>
-                                        <select value={entry.inventoryId} onChange={(e) => handleInventoryChange(index, 'inventoryId', e.target.value)} required>
-                                            <option value="">Select an inventory</option>
-                                            {[...inventories]
-                                                .sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0))
-                                                .map((inv) => (
-                                                    <option key={inv.id} value={inv.id}>{inv.inventory_name}</option>
-                                                ))}
-                                        </select>
-                                    </div>
+                        {inventoryEntries.map((entry, index) => (
+                            <div key={index} className="double-input-group">
+                                <select value={entry.inventoryId} className="input-max-width" onChange={(e) => handleInventoryChange(index, 'inventoryId', e.target.value)} required>
+                                    <option value="">Select an inventory</option>
+                                    {[...inventories]
+                                        .map((inv) => (
+                                            <option key={inv.id} value={inv.id}>{inv.inventory_name}</option>
+                                        ))}
+                                </select>
 
+                                    <IconButton icon={<i className="fa-regular fa-trash-can"></i>} onClick={() => removeInventoryRow(index)} title="Remove inventory" disabled={index <= 0 && (true)} />
+                            </div>
+                        ))}
 
-
-                                    {index > 0 && (
-                                        <IconButton icon={<i className="fa-regular fa-trash-can"></i>} onClick={() => removeInventoryRow(index)} title="Remove inventory" />
-                                    )}
-                                </div>
-                            ))}
-
-                            <IconButton type="button" icon={<i className="fa-regular fa-plus"></i>} onClick={addInventoryRow} title="Add new inventory" />
-                        </div>
+                        <IconButton type="button" icon={<i className="fa-regular fa-plus"></i>} onClick={addInventoryRow} title="Add new inventory" />
                     </div>
 
                     <div className="side-panel-footer">

--- a/src/features/products/add/AddProductDialog.tsx
+++ b/src/features/products/add/AddProductDialog.tsx
@@ -17,23 +17,30 @@ type Inventory = {
     is_default?: boolean;
 };
 
+type Variant = {
+    id: string;
+    variant_name: string;
+};
+
 type Props = {
     open: boolean;
     onClose: () => void;
     categories: Category[];
+    variants?: Variant[];
     inventories: Inventory[];
 };
 
-export function AddProductDialog({ open, onClose, categories = [], inventories = [] }: Props) {
+export function AddProductDialog({ open, onClose, categories = [], variants = [], inventories = [] }: Props) {
     const [formData, setFormData] = useState({
         productName: '',
         categoryId: '',
+        variantId: '',
         status: true
     });
 
     const [inventoryEntries, setInventoryEntries] = useState([
-        { inventoryId: '' }
-    ]);
+            { inventoryId: '' }
+        ]);
 
     const [submitting, setSubmitting] = useState(false);
     const toast = useToast();
@@ -90,6 +97,7 @@ export function AddProductDialog({ open, onClose, categories = [], inventories =
                 body: JSON.stringify({
                     product_name: formData.productName,
                     product_category: formData.categoryId,
+                    product_variant: formData.variantId,
                     product_status: formData.status,
                     inventories: inventoryEntries.map(entry => ({
                         inventoryId: entry.inventoryId,
@@ -111,6 +119,7 @@ export function AddProductDialog({ open, onClose, categories = [], inventories =
             setFormData({
                 productName: '',
                 categoryId: '',
+                variantId: '',
                 status: true
             });
             setInventoryEntries([{ inventoryId: '' }]);
@@ -146,6 +155,15 @@ export function AddProductDialog({ open, onClose, categories = [], inventories =
                                     <option value="">Select a category</option>
                                     {categories.map((cat) => (
                                         <option key={cat.id} value={cat.id}>{cat.category_name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="input-equal">
+                                <label htmlFor="variantId" className="input-label">Variant</label>
+                                <select name="variantId" className="input-max-width" value={formData.variantId} onChange={handleChange}>
+                                    <option value="">Select a variant</option>
+                                    {variants.map((variant) => (
+                                        <option key={variant.id} value={variant.id}>{variant.variant_name}</option>
                                     ))}
                                 </select>
                             </div>

--- a/src/features/products/edit/EditProductButton.tsx
+++ b/src/features/products/edit/EditProductButton.tsx
@@ -10,6 +10,11 @@ type Inventory = {
     is_default?: boolean;
 };
 
+type Variant = {
+    id: string;
+    variant_name: string;
+};
+
 type ProductInventory = {
     id: string;
     inventory_id: string;
@@ -20,8 +25,10 @@ type EditProductButtonProps = {
     id: string;
     product_name: string;
     product_category: string;
+    product_variant: string;
     product_status: boolean;
     categories: Array<{ id: string; category_name: string }>;
+    variants?: Variant[];
     inventories: Inventory[];
     productInventories: ProductInventory[];
     currentInventoryId?: string;
@@ -32,8 +39,10 @@ export function EditProductButton({
     id,
     product_name,
     product_category,
+    product_variant,
     product_status,
     categories,
+    variants,
     inventories,
     productInventories,
     currentInventoryId,
@@ -45,6 +54,7 @@ export function EditProductButton({
         id,
         product_name,
         product_category,
+        product_variant,
         product_status,
         inventories: productInventories.map(pi => ({
             inventory_id: pi.inventory_id,
@@ -63,6 +73,7 @@ export function EditProductButton({
                     onClose={() => setOpen(false)}
                     product={productData}
                     categories={categories}
+                    variants={variants}
                     inventories={inventories}
                     onSuccess={onSuccess}
                 />

--- a/src/features/products/edit/EditProductButton.tsx
+++ b/src/features/products/edit/EditProductButton.tsx
@@ -7,7 +7,6 @@ import { IconButton } from '../../../components/IconButton/iconButton';
 type Inventory = {
     id: string;
     inventory_name: string;
-    is_default?: boolean;
 };
 
 type Variant = {

--- a/src/features/products/edit/EditProductDialog.tsx
+++ b/src/features/products/edit/EditProductDialog.tsx
@@ -191,7 +191,7 @@ export function EditProductDialog({
     return (
         <>
             {open && <div className="side-panel-backdrop" onClick={onClose} />}
-            <div className={`side-panel side-panel-md ${isOpen ? 'open' : ''}`} role="dialog" aria-labelledby="dialog-title">
+            <div className={`side-panel side-panel-sm ${isOpen ? 'open' : ''}`} role="dialog" aria-labelledby="dialog-title">
                 <div className="side-panel-header">
                     <h3 className="side-panel-title" id="dialog-title">Edit product</h3>
                 </div>
@@ -233,46 +233,35 @@ export function EditProductDialog({
                         </div>
 
                         <div className="input-group">
-                            <label htmlFor="product_status" className="input-label">Status</label>
                             <label>
                                 <input name="product_status" type="checkbox" checked={formData.product_status} onChange={(e) => setFormData((prev) => ({ ...prev, product_status: e.target.checked, }))} />
                                 Product is active
                             </label>
                         </div>
 
-                        <div className="boxed-section">
-                            <h4 className="section-subtitle">Inventories</h4>
+                        <h4 className="section-subtitle">Inventories</h4>
 
-                            {inventoryEntries.map((entry, index) => (
-                                <div key={index} className="double-input-group">
-                                    <div>
-                                        <label className="input-label">Inventory name</label>
-                                        <select value={entry.inventoryId} onChange={e => handleInventoryChange(index, 'inventoryId', e.target.value)} required>
-                                            <option value="">Select an inventory</option>
-                                            {inventories
-                                                .filter(inv =>
-                                                    inv.id === entry.inventoryId ||
-                                                    !inventoryEntries.some(
-                                                        (e, idx) => idx !== index && e.inventoryId === inv.id
-                                                    )
-                                                )
-                                                .map(inv => (
-                                                    <option key={inv.id} value={inv.id}>{inv.inventory_name}</option>
-                                                ))}
-                                        </select>
-                                    </div>
+                        {inventoryEntries.map((entry, index) => (
+                            <div key={index} className="double-input-group">
+                                <select value={entry.inventoryId} className="input-max-width" onChange={e => handleInventoryChange(index, 'inventoryId', e.target.value)} required>
+                                    <option value="">Select an inventory</option>
+                                    {inventories
+                                        .filter(inv =>
+                                            inv.id === entry.inventoryId ||
+                                            !inventoryEntries.some(
+                                                (e, idx) => idx !== index && e.inventoryId === inv.id
+                                            )
+                                        )
+                                        .map(inv => (
+                                            <option key={inv.id} value={inv.id}>{inv.inventory_name}</option>
+                                        ))}
+                                </select>
 
+                                <IconButton icon={<i className="fa-regular fa-trash-can"></i>} onClick={() => removeInventoryRow(index)} title="Remove inventory" disabled={index <= 0 && (true)} />
+                            </div>
+                        ))}
 
-
-                                    {inventoryEntries.length > 1 && (
-                                        <IconButton icon={<i className="fa-regular fa-trash-can"></i>} onClick={() => removeInventoryRow(index)} title="Remove inventory" />
-                                    )}
-                                </div>
-                            ))}
-
-                            <IconButton type="button" icon={<i className="fa-regular fa-plus"></i>} onClick={addInventoryRow} title="Add new inventory" />
-                        </div>
-
+                        <IconButton type="button" icon={<i className="fa-regular fa-plus"></i>} onClick={addInventoryRow} title="Add new inventory" />
                     </div>
 
                     <div className="side-panel-footer">

--- a/src/features/products/edit/EditProductDialog.tsx
+++ b/src/features/products/edit/EditProductDialog.tsx
@@ -16,6 +16,11 @@ type Inventory = {
     inventory_name: string;
 };
 
+type Variant = {
+    id: string;
+    variant_name: string;
+};
+
 type ProductInventoryData = {
     inventory_id: string;
 };
@@ -24,6 +29,7 @@ type ProductData = {
     id: string;
     product_name: string;
     product_category: string;
+    product_variant: string | null;
     product_status: boolean;
     inventories: ProductInventoryData[];
     currentInventoryId?: string;
@@ -34,6 +40,7 @@ type EditProductDialogProps = {
     onClose: () => void;
     product: ProductData;
     categories: Category[];
+    variants?: Variant[];
     inventories: Inventory[];
     onSuccess?: () => void;
 };
@@ -43,6 +50,7 @@ export function EditProductDialog({
     onClose,
     product,
     categories,
+    variants = [],
     inventories,
     onSuccess,
 }: EditProductDialogProps) {
@@ -65,6 +73,7 @@ export function EditProductDialog({
     const [formData, setFormData] = useState({
         product_name: product.product_name || '',
         product_category: product.product_category || '',
+        product_variant: product.product_variant || '',
         product_status: product.product_status ?? false,
     });
 
@@ -76,6 +85,7 @@ export function EditProductDialog({
         setFormData({
             product_name: product.product_name || '',
             product_category: product.product_category || '',
+            product_variant: product.product_variant || '',
             product_status: product.product_status ?? false,
         });
 
@@ -146,6 +156,7 @@ export function EditProductDialog({
                     id: product.id,
                     product_name: formData.product_name,
                     product_category: formData.product_category,
+                    product_variant: formData.product_variant,
                     product_status: formData.product_status,
                     inventories: inventoryEntries.map(entry => ({
                         inventory_id: entry.inventoryId,
@@ -202,6 +213,19 @@ export function EditProductDialog({
                                     {categories.map(cat => (
                                         <option key={cat.id} value={cat.id}>
                                             {cat.category_name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="input-equal">
+                                <label htmlFor="product_variant" className="input-label">
+                                    Variant
+                                </label>
+                                <select name="product_variant" className="input-max-width" value={formData.product_variant} onChange={handleChange}>
+                                    <option value="">Select a variant</option>
+                                    {variants.map(variant => (
+                                        <option key={variant.id} value={variant.id}>
+                                            {variant.variant_name}
                                         </option>
                                     ))}
                                 </select>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -40,6 +40,11 @@ main {
     font-size: 2rem;
 }
 
+.heading-subtitle {
+    color: #8b71a4;
+    font-size: 1.2rem;
+}
+
 .pageHeader {
     display: flex;
     justify-content: space-between;
@@ -474,12 +479,6 @@ textarea {
 .side-panel-title {
     font-family: titleFont;
     font-size: 1.5rem;
-}
-
-.boxed-section {
-    background-color: #F7F3FF;
-    border-radius: 4px;
-    padding: 1rem;
 }
 
 /* BATCH TABLE */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -54,7 +54,6 @@ main {
     padding: .5rem 0 0;
 
     &.inventory-content {
-        border-top-left-radius: 0;
         padding-top: 1.5rem;
     }
 }
@@ -288,12 +287,16 @@ textarea {
         cursor: not-allowed;
         pointer-events: none;
     }
+
+    &:disabled {
+        background-color: #f4eefb;
+        color: #97809d;
+    }
 }
 
 .input-max-width {
     width: 100%;
 }
-
 
 .input-label {
     display: block;


### PR DESCRIPTION
## Summary
- fetch inventories in the sidebar
- make inventory section expandable and show each inventory
- style submenu links
- allow `/inventory/[inventory]` routes

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e356f444832886e504dacb82ef81