### PR TITLE
Add inventory settings and menu

### DIFF
--- a/src/app/api/inventories/addNewInventory/route.ts
+++ b/src/app/api/inventories/addNewInventory/route.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@/src/utils/supabase/server';
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), { status: 401 });
+    }
+
+    const body = await request.json();
+    const { inventory_name } = body;
+
+    if (!inventory_name || inventory_name.trim() === '') {
+      return new Response(JSON.stringify({ success: false, error: 'Inventory name is required' }), { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('inventories')
+      .insert([
+        { inventory_name, owner_id: user.id },
+      ]);
+
+    if (error) {
+      console.error('Error inserting inventory:', error);
+      return new Response(JSON.stringify({ success: false, error: error.message }), { status: 500 });
+    }
+
+    return new Response(JSON.stringify({ success: true, inventory: data }), { status: 200 });
+  } catch (error) {
+    console.error('Unexpected error:', error);
+    return new Response(JSON.stringify({ success: false, error: 'Unexpected error occurred' }), { status: 500 });
+  }
+}

--- a/src/app/api/inventories/deleteInventory/route.ts
+++ b/src/app/api/inventories/deleteInventory/route.ts
@@ -1,0 +1,30 @@
+import { createClient } from '@/src/utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+export async function DELETE(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+
+  if (!id) {
+    return NextResponse.json({ error: 'Missing ID' }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  const { count } = await supabase
+    .from('product_inventories')
+    .select('id', { count: 'exact', head: true })
+    .eq('inventory_id', id);
+
+  if ((count ?? 0) > 0) {
+    return NextResponse.json({ error: 'Inventory not empty' }, { status: 400 });
+  }
+
+  const { error } = await supabase.from('inventories').delete().eq('id', id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/inventories/updateInventory/route.ts
+++ b/src/app/api/inventories/updateInventory/route.ts
@@ -1,0 +1,25 @@
+import { createClient } from '@/src/utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+
+  const body = await request.json();
+  const { id, inventory_name } = body;
+
+  if (!id || !inventory_name) {
+    return NextResponse.json({ error: 'Missing data' }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from('inventories')
+    .update({ inventory_name })
+    .eq('id', id)
+    .select();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, data });
+}

--- a/src/app/inventories/inventories.module.css
+++ b/src/app/inventories/inventories.module.css
@@ -1,0 +1,10 @@
+.wrapper {
+    display: flex;
+    gap: 1.25rem;
+}
+
+.summary {
+    & .total {
+        font-size: 0.875rem;
+    }
+}

--- a/src/app/inventories/page.tsx
+++ b/src/app/inventories/page.tsx
@@ -1,0 +1,77 @@
+import { AddButton } from '@/src/features/inventories/add/AddButton';
+import { DeleteButton } from '@/src/features/inventories/delete/DeleteButton';
+import { EditInventoryButton } from '@/src/features/inventories/edit/EditInventoryButton';
+import { Pagination } from '@/src/components/Pagination/pagination';
+import { Search } from '@/src/components/SearchBar/searchBar';
+import { createClient } from '@/src/utils/supabase/server';
+import styles from './inventories.module.css';
+
+export default async function InventoriesPage({ searchParams }: { searchParams: any }) {
+    const supabase = await createClient();
+    const params = await searchParams;
+
+    const page = parseInt(params.page || '1');
+    const query = params.query || '';
+    const pageSize = 12;
+
+    const { data: inventories, count } = await supabase
+        .from('inventories')
+        .select('id, inventory_name, product_inventories(count)', { count: 'exact' })
+        .ilike('inventory_name', `%${query}%`)
+        .range((page - 1) * pageSize, page * pageSize - 1)
+        .order('inventory_name', { ascending: true });
+
+    const totalCount = count ?? 0;
+    const totalPages = Math.ceil(totalCount / pageSize);
+
+    return (
+        <>
+            <div className="pageHeader">
+                <h2 className="heading-title">Inventories</h2>
+                <AddButton />
+            </div>
+
+            <div className="content">
+                <div className="filter-bar">
+                    <Search placeholder="Search for inventory name" query={query} />
+                </div>
+
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Inventory name</th>
+                            <th># stored products</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {inventories && inventories.map(inv => {
+                            const productCount = inv.product_inventories ? inv.product_inventories[0]?.count ?? 0 : 0;
+                            return (
+                                <tr key={inv.id}>
+                                    <td><span className="item-name">{inv.inventory_name}</span></td>
+                                    <td>{productCount}</td>
+                                    <td>
+                                        <div className="table-actions">
+                                            <DeleteButton inventoryId={inv.id} inventoryName={inv.inventory_name} productCount={productCount} />
+                                            <EditInventoryButton inventoryId={inv.id} currentName={inv.inventory_name} />
+                                        </div>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+
+            <div className="pagination total-count">
+                <div className={styles.summary}>
+                    <div className={styles.total}>
+                        Total <strong>{totalCount}</strong> inventories
+                    </div>
+                </div>
+                <Pagination totalPages={totalPages} currentPage={page} />
+            </div>
+        </>
+    );
+}

--- a/src/components/Sidebar/sidebar.tsx
+++ b/src/components/Sidebar/sidebar.tsx
@@ -9,6 +9,7 @@ import styles from "./sidebar.module.css";
 const Sidebar = () => {
     const [isCollapsed, setIsCollapsed] = useState(false);
     const [inventoryOpen, setInventoryOpen] = useState(false);
+    const [settingsOpen, setSettingsOpen] = useState(false);
     const [inventories, setInventories] = useState<{ id: number; inventory_name: string }[]>([]);
     const pathname = usePathname();
     const searchParams = useSearchParams();
@@ -30,6 +31,8 @@ const Sidebar = () => {
 
     useEffect(() => {
         setInventoryOpen(pathname.startsWith('/inventory'));
+        const settingsPaths = ['/categories', '/supplies', '/inventories'];
+        setSettingsOpen(settingsPaths.some(p => pathname.startsWith(p)));
     }, [pathname]);
 
     return (
@@ -74,16 +77,24 @@ const Sidebar = () => {
                             </Link>
                         </li>
                         <li>
-                            <Link className={`${styles.navigationLink} ${pathname === '/supplies' ? styles.active : ''}`} href="/supplies" title="Supplies">
-                                <i className="fa-solid fa-layer-group"></i>
-                                {!isCollapsed && <span>Supplies</span>}
-                            </Link>
-                        </li>
-                        <li>
-                            <Link className={`${styles.navigationLink} ${pathname === '/categories' ? styles.active : ''}`} href="/categories" title="Categories">
-                                <i className="fa-solid fa-boxes-stacked"></i>
-                                {!isCollapsed && <span>Categories</span>}
-                            </Link>
+                            <button type="button" className={`${styles.navigationLink} ${pathname.startsWith('/supplies') || pathname.startsWith('/categories') || pathname.startsWith('/inventories') ? styles.active : ''}`} onClick={() => setSettingsOpen(prev => !prev)}>
+                                <i className="fa-solid fa-gear"></i>
+                                {!isCollapsed && <span>Settings</span>}
+                                {!isCollapsed && <i className={`${styles.chevron} fa-solid ${settingsOpen ? 'fa-chevron-down' : 'fa-chevron-right'}`}></i>}
+                            </button>
+                            {!isCollapsed && settingsOpen && (
+                                <ul className={styles.subMenu}>
+                                    <li>
+                                        <Link href="/inventories" className={`${styles.subLink} ${pathname === '/inventories' ? styles.active : ''}`}>Inventories</Link>
+                                    </li>
+                                    <li>
+                                        <Link href="/supplies" className={`${styles.subLink} ${pathname === '/supplies' ? styles.active : ''}`}>Supplies</Link>
+                                    </li>
+                                    <li>
+                                        <Link href="/categories" className={`${styles.subLink} ${pathname === '/categories' ? styles.active : ''}`}>Categories</Link>
+                                    </li>
+                                </ul>
+                            )}
                         </li>
                         <li>
                             <Link className={`${styles.navigationLink} ${pathname === '/variants' ? styles.active : ''}`} href="/variants" title="Variants">

--- a/src/features/inventories/add/AddButton.tsx
+++ b/src/features/inventories/add/AddButton.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/src/components/Button/button';
+import { CgMathPlus } from 'react-icons/cg';
+import { AddInventoryDialog } from './AddInventoryDialog';
+
+export function AddButton() {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <Button variant="cta" onClick={() => setOpen(true)} icon={<CgMathPlus />}>Add new inventory</Button>
+            {open && <AddInventoryDialog open={open} onClose={() => setOpen(false)} />}
+        </>
+    );
+}

--- a/src/features/inventories/add/AddInventoryDialog.tsx
+++ b/src/features/inventories/add/AddInventoryDialog.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Button } from '@/src/components/Button/button';
+import { Dialog } from '@/src/components/Dialog/dialog';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useToast } from '@/src/components/Toast/toast';
+
+type Props = {
+    open: boolean;
+    onClose: () => void;
+};
+
+export function AddInventoryDialog({ open, onClose }: Props) {
+    const [name, setName] = useState('');
+    const toast = useToast();
+    const router = useRouter();
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        const response = await fetch('/api/inventories/addNewInventory', {
+            method: 'POST',
+            body: JSON.stringify({ inventory_name: name }),
+            headers: { 'Content-Type': 'application/json' },
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+            toast('✅ Inventory created!');
+            router.refresh();
+            onClose();
+            setName('');
+        } else {
+            toast(`Error: ${result.error}`);
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} title="Add new inventory">
+            <form onSubmit={handleSubmit} method="dialog">
+                <div className="input-group">
+                    <label className="input-label">Name</label>
+                    <input value={name} onChange={(e) => setName(e.target.value)} required />
+                </div>
+
+                <div className="dialog-buttons">
+                    <Button variant="ghost" onClick={onClose} type="button">Cancel</Button>
+                    <Button variant="primary" type="submit">Save</Button>
+                </div>
+            </form>
+        </Dialog>
+    );
+}

--- a/src/features/inventories/delete/DeleteButton.tsx
+++ b/src/features/inventories/delete/DeleteButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { IconButton } from '@/src/components/IconButton/iconButton';
+import { useToast } from '@/src/components/Toast/toast';
+import { useRouter } from 'next/navigation';
+import { DeleteConfirmationDialog } from './DeleteConfirmationDialog';
+
+type Props = {
+    inventoryId: string;
+    inventoryName: string;
+    productCount: number;
+};
+
+export const DeleteButton = ({ inventoryId, inventoryName, productCount }: Props) => {
+    const [open, setOpen] = useState(false);
+    const toast = useToast();
+    const router = useRouter();
+
+    const handleDelete = async () => {
+        try {
+            const res = await fetch(`/api/inventories/deleteInventory?id=${inventoryId}`, { method: 'DELETE' });
+            if (res.ok) {
+                toast('✅ Inventory successfully deleted');
+                router.refresh();
+            } else {
+                const data = await res.json();
+                toast(`🚫 ${data.error || 'Failed to delete inventory'}`);
+            }
+        } catch (error) {
+            console.error('Error deleting inventory', error);
+        }
+    };
+
+    const disabled = productCount > 0;
+
+    return (
+        <>
+            <IconButton icon={<i className="fa-regular fa-trash-can"></i>} onClick={() => !disabled && setOpen(true)} title="Delete inventory" disabled={disabled} />
+            {open && (
+                <DeleteConfirmationDialog open={open} onClose={() => setOpen(false)} onConfirm={handleDelete} inventoryName={inventoryName} />
+            )}
+        </>
+    );
+};

--- a/src/features/inventories/delete/DeleteConfirmationDialog.tsx
+++ b/src/features/inventories/delete/DeleteConfirmationDialog.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@/src/components/Button/button';
+import { Dialog } from '@/src/components/Dialog/dialog';
+
+type Props = {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    inventoryName: string;
+};
+
+export const DeleteConfirmationDialog = ({ open, onClose, onConfirm, inventoryName }: Props) => {
+    const handleClose = () => {
+        onClose();
+    };
+
+    const handleConfirm = () => {
+        onConfirm();
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} title="Delete this inventory?">
+            <p>You are about to send <strong>{inventoryName}</strong> to the digital abyss.</p>
+            <p>This action is only allowed for empty inventories.</p>
+            <div className="dialog-buttons">
+                <Button variant="ghost" onClick={handleClose} type="button">Never mind</Button>
+                <Button variant="destructive" onClick={handleConfirm}>Yes, delete</Button>
+            </div>
+        </Dialog>
+    );
+};

--- a/src/features/inventories/edit/EditInventoryButton.tsx
+++ b/src/features/inventories/edit/EditInventoryButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import { IconButton } from '@/src/components/IconButton/iconButton';
+import { EditInventoryDialog } from './EditInventoryDialog';
+
+type Props = {
+    inventoryId: string;
+    currentName: string;
+};
+
+export function EditInventoryButton({ inventoryId, currentName }: Props) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <IconButton icon={<i className="fa-regular fa-pen-to-square"></i>} onClick={() => setOpen(true)} title="Edit" />
+            {open && (
+                <EditInventoryDialog id={inventoryId} currentName={currentName} open={open} onClose={() => setOpen(false)} />
+            )}
+        </>
+    );
+}

--- a/src/features/inventories/edit/EditInventoryDialog.tsx
+++ b/src/features/inventories/edit/EditInventoryDialog.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/src/components/Button/button';
+import { Dialog } from '@/src/components/Dialog/dialog';
+import { useToast } from '@/src/components/Toast/toast';
+
+type Props = {
+    id: string;
+    currentName: string;
+    open: boolean;
+    onClose: () => void;
+};
+
+export function EditInventoryDialog({ id, currentName, open, onClose }: Props) {
+    const [name, setName] = useState(currentName);
+    const toast = useToast();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (open) setName(currentName);
+    }, [open, currentName]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const response = await fetch('/api/inventories/updateInventory', {
+            method: 'PUT',
+            body: JSON.stringify({ id, inventory_name: name }),
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const result = await response.json();
+        if (result.success) {
+            toast('✅ Inventory updated!');
+            router.refresh();
+            onClose();
+        } else {
+            toast(`Error: ${result.error}`);
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} title="Edit inventory">
+            <form onSubmit={handleSubmit} method="dialog">
+                <div className="input-group">
+                    <label className="input-label">Name</label>
+                    <input value={name} onChange={(e) => setName(e.target.value)} required />
+                </div>
+                <div className="dialog-buttons">
+                    <Button variant="ghost" onClick={onClose} type="button">Cancel</Button>
+                    <Button variant="primary" type="submit">Save</Button>
+                </div>
+            </form>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
## Summary
- add Settings menu and move Supplies and Categories under it
- implement inventory management page and UI components
- enforce deletion only if inventories are empty
- expose API routes to add, update and delete inventories

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ff272f5883288a2ec18db8b19aeb