### PR TITLE
Add editable profile page

### DIFF
--- a/src/app/api/profile/changePassword/route.ts
+++ b/src/app/api/profile/changePassword/route.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@/src/utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { password } = await request.json();
+  if (!password || password.trim() === '') {
+    return NextResponse.json({ success: false, error: 'Password is required' }, { status: 400 });
+  }
+
+  const { error } = await supabase.auth.updateUser({ password });
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@/src/utils/supabase/server';
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', user.id)
+    .single();
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+  }
+
+  return new Response(
+    JSON.stringify({ email: user.email, username: profile?.username || '' }),
+    { status: 200 },
+  );
+}

--- a/src/app/api/profile/updateUsername/route.ts
+++ b/src/app/api/profile/updateUsername/route.ts
@@ -1,0 +1,30 @@
+import { createClient } from '@/src/utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { username } = await request.json();
+  if (!username || username.trim() === '') {
+    return NextResponse.json({ success: false, error: 'Username is required' }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ username })
+    .eq('id', user.id);
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/profile/ProfileForm.tsx
+++ b/src/app/profile/ProfileForm.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/src/components/Button/button';
+import { useToast } from '@/src/components/Toast/toast';
+import styles from './profile.module.css';
+
+type Props = {
+  email: string;
+  initialUsername: string;
+};
+
+export default function ProfileForm({ email, initialUsername }: Props) {
+  const [username, setUsername] = useState(initialUsername);
+  const [password, setPassword] = useState('');
+  const toast = useToast();
+  const router = useRouter();
+
+  const updateUsername = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/profile/updateUsername', {
+      method: 'PUT',
+      body: JSON.stringify({ username }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const result = await res.json();
+    if (result.success) {
+      toast('✅ Username updated!');
+      router.refresh();
+    } else {
+      toast(`Error: ${result.error}`);
+    }
+  };
+
+  const changePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/profile/changePassword', {
+      method: 'PUT',
+      body: JSON.stringify({ password }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const result = await res.json();
+    if (result.success) {
+      toast('✅ Password updated!');
+      setPassword('');
+    } else {
+      toast(`Error: ${result.error}`);
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div className="input-group">
+        <label className="input-label">Email</label>
+        <input type="email" value={email} readOnly />
+      </div>
+
+      <form onSubmit={updateUsername} className={styles.form}>
+        <div className="input-group">
+          <label className="input-label">Username</label>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+        </div>
+        <div className={styles.formAction}>
+          <Button variant="primary" type="submit">Save username</Button>
+        </div>
+      </form>
+
+      <form onSubmit={changePassword} className={styles.form}>
+        <div className="input-group">
+          <label className="input-label">New password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <div className={styles.formAction}>
+          <Button variant="secondary" type="submit">Change password</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,31 @@
+import { createClient } from '@/src/utils/supabase/server';
+import { redirect } from 'next/navigation';
+import ProfileForm from './ProfileForm';
+
+export default async function ProfilePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { data } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', user.id)
+    .single();
+
+  return (
+    <>
+      <div className="pageHeader">
+        <h2 className="heading-title">Profile</h2>
+      </div>
+      <div className="content">
+        <ProfileForm email={user.email ?? ''} initialUsername={data?.username ?? ''} />
+      </div>
+    </>
+  );
+}

--- a/src/app/profile/profile.module.css
+++ b/src/app/profile/profile.module.css
@@ -1,0 +1,12 @@
+.wrapper {
+    padding: 1.5rem;
+    max-width: 400px;
+}
+
+.form {
+    margin-bottom: 1.5rem;
+}
+
+.formAction {
+    margin-top: 0.5rem;
+}

--- a/src/components/Sidebar/sidebar.tsx
+++ b/src/components/Sidebar/sidebar.tsx
@@ -11,6 +11,7 @@ const Sidebar = () => {
     const [inventoryOpen, setInventoryOpen] = useState(false);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [inventories, setInventories] = useState<{ id: number; inventory_name: string }[]>([]);
+    const [username, setUsername] = useState('');
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
@@ -27,6 +28,21 @@ const Sidebar = () => {
             }
         };
         load();
+    }, []);
+
+    useEffect(() => {
+        const loadProfile = async () => {
+            try {
+                const res = await fetch('/api/profile');
+                if (res.ok) {
+                    const data = await res.json();
+                    setUsername(data.username || '');
+                }
+            } catch (err) {
+                console.error('Failed to load profile', err);
+            }
+        };
+        loadProfile();
     }, []);
 
     useEffect(() => {
@@ -107,7 +123,7 @@ const Sidebar = () => {
 
             <Link className={`${styles.profileLink} ${pathname === '/profile' ? styles.active : ''}`} href="/profile">
                 <span><Image src="/images/avatar.jpg" alt="Profile picture" className={styles["profile-image"]} width={120} height={120} /></span>
-                <span className={styles["profile-name"]}>Stefanie</span>
+                <span className={styles["profile-name"]}>{username || 'Profile'}</span>
             </Link>
         </aside>
     );


### PR DESCRIPTION
## Summary
- create a profile page where users can see email and update username/password
- expose API endpoints to read profile info and apply updates
- load the username in the sidebar via new profile API

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68691ad2b6e08328a544f2b7f0fb9a3a