### PR TITLE
Hide sidebar if not logged in

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "../../styles/globals.css";
 
 import Sidebar from '../components/Sidebar/sidebar';
 import { Suspense } from 'react';
+import { createClient } from '../utils/supabase/server';
 
 const geistSans = Quicksand({
   variable: "--font-quicksand",
@@ -18,15 +19,20 @@ export const metadata: Metadata = {
   description: "Super cute inventory management",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
   return (
     <html lang="en">
       <body className={geistSans.variable}>
         <ProfileProvider>
           <ToastProvider>
-            <Suspense fallback={null}>
-              <Sidebar />
-            </Suspense>
+            {user && (
+              <Suspense fallback={null}>
+                <Sidebar />
+              </Suspense>
+            )}
             <main>
               {children}
             </main>


### PR DESCRIPTION
## Summary
- check user session in RootLayout
- only render the sidebar when a user exists

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for '@types/node')*

------
https://chatgpt.com/codex/tasks/task_e_686938535aac8328b11e313aba19c547