### PR TITLE
Hide inactive supply batches when selecting for product batches

### DIFF
--- a/src/features/products/batches/AddProductBatchPanel.tsx
+++ b/src/features/products/batches/AddProductBatchPanel.tsx
@@ -12,7 +12,7 @@ export type SupplyOption = {
     supply_name: string;
     supply_categories?: { id: string; category_name: string };
 };
-export type SupplyBatchOption = { id: string; batch_name: string };
+export type SupplyBatchOption = { id: string; batch_name: string; status: boolean };
 
 export type ProductBatchSupply = {
     supplyId: string;
@@ -118,7 +118,10 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
                         const res = await fetch(`/api/supplies/batches/?supplyId=${s.id}`);
                         if (res.ok) {
                             const data = await res.json();
-                            map[s.id] = data.batches || [];
+                            const activeBatches = (data.batches || []).filter(
+                                (b: SupplyBatchOption) => b.status
+                            );
+                            map[s.id] = activeBatches;
                         }
                     } catch (err) {
                         console.error(err);
@@ -144,7 +147,9 @@ export default function AddProductBatchPanel({ open, onClose, productId, product
                     const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
                     if (res.ok) {
                         const data = await res.json();
-                        batches = data.batches || [];
+                        batches = (data.batches || []).filter(
+                            (b: SupplyBatchOption) => b.status
+                        );
                         setSupplyBatches((prev) => ({ ...prev, [selectedSupply]: batches! }));
                     }
                 } catch (err) {

--- a/src/features/products/batches/EditProductBatchPanel.tsx
+++ b/src/features/products/batches/EditProductBatchPanel.tsx
@@ -104,7 +104,10 @@ export default function EditProductBatchPanel({ open, onClose, batch, onUpdated 
                         const res = await fetch(`/api/supplies/batches/?supplyId=${s.id}`);
                         if (res.ok) {
                             const data = await res.json();
-                            map[s.id] = data.batches || [];
+                            const activeBatches = (data.batches || []).filter(
+                                (b: SupplyBatchOption) => b.status
+                            );
+                            map[s.id] = activeBatches;
                         }
                     } catch (err) {
                         console.error(err);
@@ -147,7 +150,9 @@ export default function EditProductBatchPanel({ open, onClose, batch, onUpdated 
                     const res = await fetch(`/api/supplies/batches/?supplyId=${selectedSupply}`);
                     if (res.ok) {
                         const data = await res.json();
-                        batches = data.batches || [];
+                        batches = (data.batches || []).filter(
+                            (b: SupplyBatchOption) => b.status
+                        );
                         setSupplyBatches((prev) => ({ ...prev, [selectedSupply]: batches! }));
                     }
                 } catch (err) {


### PR DESCRIPTION
## Summary
- extend `SupplyBatchOption` with a status flag
- filter supply batch lookups to exclude inactive batches when creating or editing product batches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e0163f3a08328a3fa5b4da17ba7cb