### PR TITLE
feat: add interactive SKU scanning page

### DIFF
--- a/src/app/api/inventory/updateStockBySku/route.ts
+++ b/src/app/api/inventory/updateStockBySku/route.ts
@@ -1,0 +1,62 @@
+import { createClient } from '@/src/utils/supabase/server';
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Unauthorized' }),
+      { status: 401 }
+    );
+  }
+
+  const body = await request.json();
+  const { items } = body;
+
+  if (!Array.isArray(items) || items.length === 0) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'No items provided' }),
+      { status: 400 }
+    );
+  }
+
+  try {
+    for (const item of items) {
+      const { sku, quantity } = item;
+      if (!sku || typeof quantity !== 'number') continue;
+
+      const { data, error } = await supabase
+        .from('product_inventories')
+        .select('product_quantity')
+        .eq('product_sku', sku)
+        .eq('owner_id', user.id)
+        .single();
+
+      if (error || !data) continue;
+
+      const newQuantity = Math.max((data.product_quantity ?? 0) - quantity, 0);
+
+      const { error: updateError } = await supabase
+        .from('product_inventories')
+        .update({ product_quantity: newQuantity })
+        .eq('product_sku', sku)
+        .eq('owner_id', user.id);
+
+      if (updateError) throw updateError;
+    }
+
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  } catch (error: unknown) {
+    console.error('Error updating stock by SKU:', error);
+    const message =
+      error instanceof Error ? error.message : 'Failed to update stock';
+    return new Response(
+      JSON.stringify({ success: false, error: message }),
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/products/searchBySku/route.ts
+++ b/src/app/api/products/searchBySku/route.ts
@@ -24,12 +24,21 @@ export async function GET(request: Request) {
         );
     }
 
+    type InventoryWithProduct = {
+        product_id: string;
+        product_sku: string;
+        products:
+            | { product_name: string | null }
+            | { product_name: string | null }[]
+            | null;
+    };
+
     const { data, error } = await supabase
         .from('product_inventories')
         .select('product_id, product_sku, products (product_name)')
         .eq('product_sku', sku)
         .eq('owner_id', user.id)
-        .single();
+        .single<InventoryWithProduct>();
 
     if (error || !data) {
         return new Response(
@@ -38,12 +47,14 @@ export async function GET(request: Request) {
         );
     }
 
+    const productName = Array.isArray(data.products)
+        ? data.products[0]?.product_name ?? ''
+        : data.products?.product_name ?? '';
+
     const product = {
         id: data.product_id,
         product_sku: data.product_sku,
-        product_name: Array.isArray(data.products)
-            ? data.products[0]?.product_name || ''
-            : data.products?.product_name || '',
+        product_name: productName,
     };
 
     return new Response(

--- a/src/app/api/products/searchBySku/route.ts
+++ b/src/app/api/products/searchBySku/route.ts
@@ -1,0 +1,51 @@
+import { createClient } from '@/src/utils/supabase/server';
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+    const sku = searchParams.get('sku');
+
+    if (!sku) {
+        return new Response(
+            JSON.stringify({ success: false, error: 'Missing sku' }),
+            { status: 400 }
+        );
+    }
+
+    const supabase = await createClient();
+    const {
+        data: { user },
+        error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+        return new Response(
+            JSON.stringify({ success: false, error: 'Unauthorized' }),
+            { status: 401 }
+        );
+    }
+
+    const { data, error } = await supabase
+        .from('product_inventories')
+        .select('product_id, product_sku, products (product_name)')
+        .eq('product_sku', sku)
+        .eq('owner_id', user.id)
+        .single();
+
+    if (error || !data) {
+        return new Response(
+            JSON.stringify({ success: false, error: 'Product not found' }),
+            { status: 404 }
+        );
+    }
+
+    const product = {
+        id: data.product_id,
+        product_sku: data.product_sku,
+        product_name: data.products?.product_name || '',
+    };
+
+    return new Response(
+        JSON.stringify({ success: true, product }),
+        { status: 200 }
+    );
+}

--- a/src/app/api/products/searchBySku/route.ts
+++ b/src/app/api/products/searchBySku/route.ts
@@ -41,7 +41,9 @@ export async function GET(request: Request) {
     const product = {
         id: data.product_id,
         product_sku: data.product_sku,
-        product_name: data.products?.product_name || '',
+        product_name: Array.isArray(data.products)
+            ? data.products[0]?.product_name || ''
+            : data.products?.product_name || '',
     };
 
     return new Response(

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Button } from '@/src/components/Button/button';
 import { IconButton } from '@/src/components/IconButton/iconButton';
@@ -17,6 +17,15 @@ export default function ScanPage() {
     const [input, setInput] = useState('');
     const [error, setError] = useState('');
     const [scannedItems, setScannedItems] = useState<ScannedItem[]>([]);
+    const [isSmiling, setIsSmiling] = useState(false);
+    const smileTimeout = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(
+        () => () => {
+            if (smileTimeout.current) clearTimeout(smileTimeout.current);
+        },
+        [],
+    );
     const toast = useToast();
 
     const handleAdd = async () => {
@@ -50,7 +59,9 @@ export default function ScanPage() {
                     },
                 ];
             });
-
+            if (smileTimeout.current) clearTimeout(smileTimeout.current);
+            setIsSmiling(true);
+            smileTimeout.current = setTimeout(() => setIsSmiling(false), 1200);
             setInput('');
             setError('');
         } catch (e) {
@@ -131,6 +142,12 @@ export default function ScanPage() {
             </div>
 
             <div className={styles['scanning-area']}>
+                <div
+                    className={`${styles.face} ${isSmiling ? styles.smile : ''}`}
+                    aria-hidden="true"
+                >
+                    <div className={styles.mouth}></div>
+                </div>
                 <Image
                     src="/images/scan_barcode.png"
                     alt="Scan items"

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -92,9 +92,7 @@ export default function ScanPage() {
     };
 
     const handleCopy = () => {
-        const text = scannedItems
-            .flatMap((item) => Array(item.quantity).fill(item.sku))
-            .join('\n');
+        const text = Array.from(new Set(scannedItems.map((item) => item.sku))).join('\n');
         navigator.clipboard.writeText(text);
         toast('SKUs copied to clipboard');
     };

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -1,8 +1,102 @@
-import { Button } from '@/src/components/Button/button';
+"use client";
+
+import { useState } from 'react';
 import Image from 'next/image';
+import { Button } from '@/src/components/Button/button';
+import { IconButton } from '@/src/components/IconButton/iconButton';
 import styles from './scan.module.css';
 
-export default async function ScanPage() {
+interface ScannedItem {
+    sku: string;
+    name: string;
+    quantity: number;
+}
+
+export default function ScanPage() {
+    const [input, setInput] = useState('');
+    const [error, setError] = useState('');
+    const [scannedItems, setScannedItems] = useState<ScannedItem[]>([]);
+
+    const handleAdd = async () => {
+        const sku = input.trim();
+        if (!sku) return;
+
+        try {
+            const response = await fetch(`/api/products/searchBySku?sku=${encodeURIComponent(sku)}`);
+            const data = await response.json();
+
+            if (!data.success || !data.product) {
+                setError('Product not found');
+                return;
+            }
+
+            setScannedItems((prev) => {
+                const existing = prev.find((item) => item.sku === sku);
+                if (existing) {
+                    return prev.map((item) =>
+                        item.sku === sku
+                            ? { ...item, quantity: item.quantity + 1 }
+                            : item,
+                    );
+                }
+                return [
+                    ...prev,
+                    {
+                        sku,
+                        name: data.product.product_name || 'Unknown product',
+                        quantity: 1,
+                    },
+                ];
+            });
+
+            setInput('');
+            setError('');
+        } catch (e) {
+            console.error(e);
+            setError('Error searching for product');
+        }
+    };
+
+    const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            await handleAdd();
+        }
+    };
+
+    const increment = (sku: string) =>
+        setScannedItems((prev) =>
+            prev.map((item) =>
+                item.sku === sku ? { ...item, quantity: item.quantity + 1 } : item,
+            ),
+        );
+
+    const decrement = (sku: string) =>
+        setScannedItems((prev) =>
+            prev.flatMap((item) => {
+                if (item.sku !== sku) return [item];
+                const quantity = item.quantity - 1;
+                return quantity > 0 ? [{ ...item, quantity }] : [];
+            }),
+        );
+
+    const remove = (sku: string) =>
+        setScannedItems((prev) => prev.filter((item) => item.sku !== sku));
+
+    const reset = () => {
+        setScannedItems([]);
+        setInput('');
+        setError('');
+    };
+
+    const handleCopy = () => {
+        const text = scannedItems
+            .flatMap((item) => Array(item.quantity).fill(item.sku))
+            .join('\n');
+        navigator.clipboard.writeText(text);
+    };
+
+    const total = scannedItems.reduce((sum, item) => sum + item.quantity, 0);
 
     return (
         <>
@@ -10,26 +104,83 @@ export default async function ScanPage() {
                 <h2 className="heading-title">Scan items</h2>
             </div>
 
-            <div className={styles["scanning-area"]}>
-                <Image src="/images/scan_barcode.png" alt="Scan items" className={styles["barcode-image"]} width={200} height={200} />
+            <div className={styles['scanning-area']}>
+                <Image
+                    src="/images/scan_barcode.png"
+                    alt="Scan items"
+                    className={styles['barcode-image']}
+                    width={200}
+                    height={200}
+                />
 
-                <input type="text" className={styles["barcode-input"]} placeholder="Scan an item" />
+                <input
+                    type="text"
+                    className={styles['barcode-input']}
+                    placeholder="Scan or enter SKU"
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                />
+                {error && <div className={styles.error}>{error}</div>}
 
-                <div className={styles["scanned-items-list"]}>
-                    <ul className={styles.list} id="scannedItemsList">
-                        <li className={styles.item}>Dachshund Valentine Day card <span className={styles.counter}>1</span></li>
-                        <li className={styles.item}>Illustarted calendar 2025 <span className={styles.counter}>10</span></li>
-                        <li className={styles.item}>Pidgeon vinyl sticker <span className={styles.counter}>999</span></li>
-                    </ul>
+                {scannedItems.length > 0 && (
+                    <div className={styles['scanned-items-list']}>
+                        <ul className={styles.list} id="scannedItemsList">
+                            {scannedItems.map((item) => (
+                                <li key={item.sku} className={styles.item}>
+                                    <span>
+                                        {item.name} <span className={styles.sku}>{item.sku}</span>
+                                    </span>
+                                    <div className={styles.controls}>
+                                        <IconButton
+                                            size="sm"
+                                            title="Decrease"
+                                            onClick={() => decrement(item.sku)}
+                                            disabled={item.quantity <= 1}
+                                            icon={<i className="fa-solid fa-minus"></i>}
+                                        />
+                                        <span className={styles.counter}>{item.quantity}</span>
+                                        <IconButton
+                                            size="sm"
+                                            title="Increase"
+                                            onClick={() => increment(item.sku)}
+                                            icon={<i className="fa-solid fa-plus"></i>}
+                                        />
+                                        <IconButton
+                                            size="sm"
+                                            title="Remove"
+                                            onClick={() => remove(item.sku)}
+                                            icon={<i className="fa-regular fa-trash-can"></i>}
+                                        />
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
 
-                    <div className={styles["total-scanned-items"]}>
-                        <span>Total scanned items:</span>
-                        1010
+                        <div className={styles['total-scanned-items']}>
+                            <span>Total scanned items:</span>
+                            {total}
+                        </div>
+
+                        <Button
+                            variant="primary"
+                            className={styles['copy-button']}
+                            onClick={handleCopy}
+                        >
+                            Copy SKUs
+                        </Button>
                     </div>
-                </div>
+                )}
 
-                <Button variant="secondary" className={styles["reset-button"]}>Reset list</Button>
+                <Button
+                    variant="secondary"
+                    className={styles['reset-button']}
+                    onClick={reset}
+                    disabled={scannedItems.length === 0}
+                >
+                    Reset list
+                </Button>
             </div>
         </>
     );
-};
+}

--- a/src/app/scan/scan.module.css
+++ b/src/app/scan/scan.module.css
@@ -14,6 +14,59 @@
     width: 100%;
 }
 
+.face {
+    background: #ffe066;
+    border-radius: 50%;
+    height: 60px;
+    margin: 0 auto 1rem;
+    position: relative;
+    width: 60px;
+}
+
+.face::before,
+.face::after {
+    background: #333;
+    border-radius: 50%;
+    content: '';
+    height: 8px;
+    position: absolute;
+    top: 20px;
+    width: 8px;
+}
+
+.face::before {
+    left: 18px;
+}
+
+.face::after {
+    right: 18px;
+}
+
+.mouth {
+    background: #333;
+    border-radius: 2px;
+    bottom: 20px;
+    height: 4px;
+    left: 50%;
+    position: absolute;
+    transform: translateX(-50%);
+    transition: all 0.3s ease;
+    width: 20px;
+}
+
+.smile {}
+
+.smile .mouth {
+    background: transparent;
+    border: 4px solid #333;
+    border-top: none;
+    border-bottom-left-radius: 14px;
+    border-bottom-right-radius: 14px;
+    bottom: 14px;
+    height: 14px;
+    width: 28px;
+}
+
 .scanned-items-list {
     background: #fff;
     box-shadow: 0 0 15px 0px #c1b2c740;

--- a/src/app/scan/scan.module.css
+++ b/src/app/scan/scan.module.css
@@ -49,6 +49,7 @@
 .item {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     margin: 10px 0;
 }
 
@@ -61,6 +62,23 @@
     }
 }
 
+.controls {
+    display: flex;
+    align-items: center;
+    gap: .25rem;
+}
+
+.sku {
+    color: #A2A6BB;
+    margin-left: .5rem;
+    font-size: .875rem;
+}
+
+.error {
+    color: #B00020;
+    margin-top: .5rem;
+}
+
 .total-scanned-items {
     border-top: 1px solid #A2A6BB;
     display: flex;
@@ -69,6 +87,10 @@
     margin-top: 1rem;
     padding-top: 1rem;
     text-transform: uppercase;
+}
+
+.copy-button {
+    margin-top: 1rem;
 }
 
 .reset-button {

--- a/src/app/scan/scan.module.css
+++ b/src/app/scan/scan.module.css
@@ -93,6 +93,10 @@
     margin-top: 1rem;
 }
 
+.submit-button {
+    margin-top: .5rem;
+}
+
 .reset-button {
     margin: 4rem auto 0;
 }


### PR DESCRIPTION
## Summary
- implement client-side scan page to search products by SKU, edit quantities, reset and copy SKUs
- add API route for product lookup by SKU

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e156de4688328b934cdda74e578f8