### PR TITLE
feat: warn when scanned stock will deplete

### DIFF
--- a/src/app/api/products/searchBySku/route.ts
+++ b/src/app/api/products/searchBySku/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: Request) {
     type InventoryWithProduct = {
         product_id: string;
         product_sku: string;
+        product_quantity: number | null;
         products:
             | { product_name: string | null }
             | { product_name: string | null }[]
@@ -35,7 +36,7 @@ export async function GET(request: Request) {
 
     const { data, error } = await supabase
         .from('product_inventories')
-        .select('product_id, product_sku, products (product_name)')
+        .select('product_id, product_sku, product_quantity, products (product_name)')
         .eq('product_sku', sku)
         .eq('owner_id', user.id)
         .single<InventoryWithProduct>();
@@ -55,6 +56,7 @@ export async function GET(request: Request) {
         id: data.product_id,
         product_sku: data.product_sku,
         product_name: productName,
+        product_quantity: data.product_quantity ?? 0,
     };
 
     return new Response(

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -226,28 +226,12 @@ export default function ScanPage() {
                                                     ></i>
                                                 ) : null}
 
-                                                <IconButton
-                                                    size="sm"
-                                                    title="Decrease"
-                                                    onClick={() => decrement(item.sku)}
-                                                    disabled={item.quantity <= 1}
-                                                    icon={<i className="fa-solid fa-minus"></i>}
-                                                />
+                                                <IconButton size="sm" title="Decrease" onClick={() => decrement(item.sku)} disabled={item.quantity <= 1} icon={<i className="fa-solid fa-minus"></i>} />
 
                                                 <span className={styles.counter}>{item.quantity}</span>
 
-                                                <IconButton
-                                                    size="sm"
-                                                    title="Increase"
-                                                    onClick={() => increment(item.sku)}
-                                                    icon={<i className="fa-solid fa-plus"></i>}
-                                                />
-                                                <IconButton
-                                                    size="sm"
-                                                    title="Remove"
-                                                    onClick={() => remove(item.sku)}
-                                                    icon={<i className="fa-regular fa-trash-can"></i>}
-                                                />
+                                                <IconButton size="sm" title="Increase" onClick={() => increment(item.sku)} icon={<i className="fa-solid fa-plus"></i>} />
+                                                <IconButton size="sm" title="Remove" onClick={() => remove(item.sku)} icon={<i className="fa-regular fa-trash-can"></i>} />
                                             </div>
                                         </li>
                                     );
@@ -263,11 +247,7 @@ export default function ScanPage() {
 
                         <div className={styles.buttons}>
                             <Button variant="secondary" onClick={handleCopy}>Copy details</Button>
-                            <Button
-                                variant="primary"
-                                onClick={handleSubmit}
-                                disabled={scannedItems.length === 0 || isUpdating}
-                            >
+                            <Button variant="primary" onClick={handleSubmit} disabled={scannedItems.length === 0 || isUpdating} >
                                 Update stock
                             </Button>
                         </div>

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -13,6 +13,7 @@ interface ScannedItem {
     quantity: number;
     batches?: string[];
     productId?: string;
+    currentQuantity: number;
 }
 
 export default function ScanPage() {
@@ -82,6 +83,8 @@ export default function ScanPage() {
                                 quantity: item.quantity + 1,
                                 batches: item.batches?.length ? item.batches : activeBatches,
                                 productId: item.productId ?? productId,
+                                currentQuantity:
+                                    item.currentQuantity ?? product.product_quantity ?? 0,
                             }
                             : item,
                     );
@@ -94,6 +97,7 @@ export default function ScanPage() {
                         quantity: 1,
                         batches: activeBatches,
                         productId: productId,
+                        currentQuantity: product.product_quantity ?? 0,
                     },
                 ];
             });
@@ -197,23 +201,57 @@ export default function ScanPage() {
                     <>
                         <div className={styles['scanned-items-list']}>
                             <ul className={styles.list} id="scannedItemsList">
-                                {scannedItems.map((item) => (
-                                    <li key={item.sku} className={styles.item}>
-                                        <div>
-                                            <div className={styles.name}>{item.name}</div>
-                                            <div className={styles.sku}>{item.sku}</div>
-                                        </div>
+                                {scannedItems.map((item) => {
+                                    const outOfStock = item.currentQuantity <= 0;
+                                    const willDeplete =
+                                        item.currentQuantity > 0 &&
+                                        item.currentQuantity - item.quantity <= 0;
+                                    return (
+                                        <li key={item.sku} className={styles.item}>
+                                            <div>
+                                                <div className={styles.name}>{item.name}</div>
+                                                <div className={styles.sku}>{item.sku}</div>
+                                            </div>
 
-                                        <div className={styles.controls}>
-                                            <IconButton size="sm" title="Decrease" onClick={() => decrement(item.sku)} disabled={item.quantity <= 1} icon={<i className="fa-solid fa-minus"></i>} />
+                                            <div className={styles.controls}>
+                                                {outOfStock ? (
+                                                    <i
+                                                        className={`fa-solid fa-circle-exclamation ${styles.errorIcon}`}
+                                                        title="Item is out of stock"
+                                                    ></i>
+                                                ) : willDeplete ? (
+                                                    <i
+                                                        className={`fa-solid fa-triangle-exclamation ${styles.warningIcon}`}
+                                                        title="Quantity will drop to zero"
+                                                    ></i>
+                                                ) : null}
 
-                                            <span className={styles.counter}>{item.quantity}</span>
+                                                <IconButton
+                                                    size="sm"
+                                                    title="Decrease"
+                                                    onClick={() => decrement(item.sku)}
+                                                    disabled={item.quantity <= 1}
+                                                    icon={<i className="fa-solid fa-minus"></i>}
+                                                />
 
-                                            <IconButton size="sm" title="Increase" onClick={() => increment(item.sku)} icon={<i className="fa-solid fa-plus"></i>} />
-                                            <IconButton size="sm" title="Remove" onClick={() => remove(item.sku)} icon={<i className="fa-regular fa-trash-can"></i>} />
-                                        </div>
-                                    </li>
-                                ))}
+                                                <span className={styles.counter}>{item.quantity}</span>
+
+                                                <IconButton
+                                                    size="sm"
+                                                    title="Increase"
+                                                    onClick={() => increment(item.sku)}
+                                                    icon={<i className="fa-solid fa-plus"></i>}
+                                                />
+                                                <IconButton
+                                                    size="sm"
+                                                    title="Remove"
+                                                    onClick={() => remove(item.sku)}
+                                                    icon={<i className="fa-regular fa-trash-can"></i>}
+                                                />
+                                            </div>
+                                        </li>
+                                    );
+                                })}
                             </ul>
 
                             <div className={styles['total-scanned-items']}>

--- a/src/app/scan/scan.module.css
+++ b/src/app/scan/scan.module.css
@@ -119,6 +119,14 @@
     gap: .25rem;
 }
 
+.warningIcon {
+    color: #E67700;
+}
+
+.errorIcon {
+    color: #D93737;
+}
+
 .name {
     font-weight: 800;
 }


### PR DESCRIPTION
## Summary
- include current stock level in search-by-sku API
- show warning or error icons for scanned items when stock would reach zero
- style warning and error icons on scan page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3ec3677c8328a15c1fb23af333e8