### PR TITLE
Add stockout email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,41 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Inventory stockout notifications
+
+The inventory update API (`src/app/api/inventory/updateStockBySku/route.ts`) now detects when a product quantity reaches zero and triggers email notifications through the helper in `src/utils/email.ts`.
+
+### Required environment variables
+
+Add the following variables to your `.env.local` (or deployment environment):
+
+| Variable | Description |
+| --- | --- |
+| `ALERT_EMAIL` | Recipient for stockout alerts. Falls back to the authenticated user's email if unset. |
+| `EMAIL_FROM` | Default sender address (used if provider-specific from addresses are not supplied). |
+| `SENDGRID_API_KEY` | Optional. Enables the SendGrid REST transport. |
+| `SENDGRID_FROM_EMAIL` | Sender address used when SendGrid is active. |
+| `SUPABASE_EMAIL_FUNCTION_URL` | Optional. URL of a Supabase Edge Function that handles outbound email. |
+| `SUPABASE_EMAIL_FUNCTION_KEY` | Bearer token for the edge function (service-role or function-specific key). |
+| `SMTP_HOST` | Optional. Hostname of an SMTP server for direct delivery. |
+| `SMTP_PORT` | Port for the SMTP server (defaults to 465 when `SMTP_SECURE=true`, otherwise 587). |
+| `SMTP_SECURE` | Set to `true` to use TLS from the start of the connection. |
+| `SMTP_USER` / `SMTP_PASSWORD` | Credentials for authenticated SMTP connections. |
+| `SMTP_FROM_EMAIL` | Overrides the sender address when the SMTP transport is used. |
+| `SMTP_HELO_DOMAIN` | Optional HELO/EHLO domain (defaults to `localhost`). |
+| `SMTP_TIMEOUT_MS` | Optional timeout for SMTP operations (defaults to 15000). |
+| `SMTP_REJECT_UNAUTHORIZED` | Set to `false` to skip TLS certificate validation (not recommended for production). |
+| `ALERT_FROM_EMAIL` | Optional override for the from address used in stockout alerts. |
+
+The helper automatically chooses the first available transport in this order: SendGrid, Supabase Edge Function, or direct SMTP.
+
+### Supabase policies
+
+Ensure the following Row Level Security (RLS) policies exist in Supabase:
+
+- `product_variant_inventories`: authenticated users can `select` and `update` rows where `owner_id = auth.uid()`. The select policy must allow joining through `product_variants` → `products` so the API can read `product_name` values.
+- If a Supabase Edge Function is used for email delivery, grant it permission to send mail (typically via a service role key) and enable `invoke` access for authenticated users.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -166,6 +166,11 @@ export default function ScanPage() {
             const result = await response.json();
             if (result.success) {
                 toast('Inventories updated');
+                if (result.notificationsSent) {
+                    toast('Out-of-stock notifications sent');
+                } else if (result.notificationError) {
+                    toast(`Inventories updated, but notifications failed: ${result.notificationError}`);
+                }
                 setScannedItems([]);
             } else {
                 toast(result.error || 'Failed to update inventories');

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,0 +1,370 @@
+import net from 'node:net';
+import tls from 'node:tls';
+
+export interface SendEmailOptions {
+  to: string;
+  subject: string;
+  text?: string;
+  html?: string;
+  from?: string;
+}
+
+interface NormalizedSendEmailOptions {
+  to: string;
+  subject: string;
+  text: string;
+  from: string;
+  html?: string;
+}
+
+export interface OutOfStockEmailItem {
+  sku: string;
+  productName: string;
+}
+
+export interface SendOutOfStockEmailOptions {
+  items: OutOfStockEmailItem[];
+  userEmail?: string | null;
+  recipientEmail?: string | null;
+}
+
+export async function sendOutOfStockEmail({
+  items,
+  userEmail,
+  recipientEmail,
+}: SendOutOfStockEmailOptions): Promise<boolean> {
+  if (!items || items.length === 0) {
+    return false;
+  }
+
+  const to = recipientEmail ?? process.env.ALERT_EMAIL ?? userEmail ?? undefined;
+  if (!to) {
+    throw new Error('No alert recipient configured. Set ALERT_EMAIL or provide a recipientEmail.');
+  }
+
+  const from =
+    process.env.ALERT_FROM_EMAIL ??
+    process.env.EMAIL_FROM ??
+    process.env.SENDGRID_FROM_EMAIL ??
+    process.env.SMTP_FROM_EMAIL ??
+    userEmail ??
+    to;
+
+  const subject =
+    items.length === 1
+      ? `Out of stock: ${items[0].productName} (${items[0].sku})`
+      : `Out of stock items (${items.length})`;
+
+  const itemLines = items
+    .map(item => `• ${item.productName} (SKU: ${item.sku})`)
+    .join('\n');
+
+  const textParts = ['The following items have just reached zero stock:', '', itemLines];
+
+  if (userEmail) {
+    textParts.push('', `Updated by: ${userEmail}`);
+  }
+
+  const text = textParts.join('\n');
+  const html = buildHtmlBody(items, userEmail);
+
+  await sendEmail({
+    to,
+    from,
+    subject,
+    text,
+    html,
+  });
+
+  return true;
+}
+
+export async function sendEmail(options: SendEmailOptions): Promise<void> {
+  const normalized = normalizeOptions(options);
+
+  if (process.env.SENDGRID_API_KEY) {
+    await sendViaSendGrid(normalized);
+    return;
+  }
+
+  if (process.env.SUPABASE_EMAIL_FUNCTION_URL) {
+    await sendViaSupabaseEdgeFunction(normalized);
+    return;
+  }
+
+  if (process.env.SMTP_HOST) {
+    await sendViaSmtp(normalized);
+    return;
+  }
+
+  throw new Error(
+    'No email transport configured. Provide SENDGRID_API_KEY, SUPABASE_EMAIL_FUNCTION_URL, or SMTP_HOST to enable email delivery.',
+  );
+}
+
+function normalizeOptions(options: SendEmailOptions): NormalizedSendEmailOptions {
+  if (!options.to) {
+    throw new Error('Missing email recipient');
+  }
+
+  if (!options.subject) {
+    throw new Error('Missing email subject');
+  }
+
+  const from =
+    options.from ??
+    process.env.EMAIL_FROM ??
+    process.env.SENDGRID_FROM_EMAIL ??
+    process.env.SMTP_FROM_EMAIL ??
+    process.env.SMTP_USER;
+
+  if (!from) {
+    throw new Error('Missing from email. Set EMAIL_FROM, SENDGRID_FROM_EMAIL, or SMTP_FROM_EMAIL.');
+  }
+
+  const html = options.html;
+  const text = options.text ?? (html ? stripHtml(html) : undefined);
+
+  if (!text) {
+    throw new Error('Email body is empty. Provide text or html content.');
+  }
+
+  return {
+    to: options.to,
+    subject: options.subject,
+    text,
+    from,
+    html,
+  };
+}
+
+async function sendViaSendGrid(options: NormalizedSendEmailOptions): Promise<void> {
+  const apiKey = process.env.SENDGRID_API_KEY;
+  if (!apiKey) {
+    throw new Error('SENDGRID_API_KEY is not configured.');
+  }
+
+  const content: Array<{ type: string; value: string }> = [
+    { type: 'text/plain', value: options.text },
+  ];
+
+  if (options.html) {
+    content.push({ type: 'text/html', value: options.html });
+  }
+
+  const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: options.to }] }],
+      from: { email: options.from },
+      subject: options.subject,
+      content,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await safeReadResponse(response);
+    throw new Error(`SendGrid request failed: ${response.status} ${errorBody}`);
+  }
+}
+
+async function sendViaSupabaseEdgeFunction(options: NormalizedSendEmailOptions): Promise<void> {
+  const url = process.env.SUPABASE_EMAIL_FUNCTION_URL;
+  if (!url) {
+    throw new Error('SUPABASE_EMAIL_FUNCTION_URL is not configured.');
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (process.env.SUPABASE_EMAIL_FUNCTION_KEY) {
+    headers.Authorization = `Bearer ${process.env.SUPABASE_EMAIL_FUNCTION_KEY}`;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      to: options.to,
+      from: options.from,
+      subject: options.subject,
+      text: options.text,
+      html: options.html,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await safeReadResponse(response);
+    throw new Error(`Supabase email function failed: ${response.status} ${errorBody}`);
+  }
+}
+
+async function sendViaSmtp(options: NormalizedSendEmailOptions): Promise<void> {
+  const host = process.env.SMTP_HOST;
+  if (!host) {
+    throw new Error('SMTP_HOST is not configured.');
+  }
+
+  const port = Number(process.env.SMTP_PORT ?? (process.env.SMTP_SECURE === 'true' ? 465 : 587));
+  const secure = (process.env.SMTP_SECURE ?? (port === 465 ? 'true' : 'false')) === 'true';
+  const user = process.env.SMTP_USER;
+  const password = process.env.SMTP_PASSWORD;
+  const helo = process.env.SMTP_HELO_DOMAIN ?? 'localhost';
+  const timeoutMs = Number(process.env.SMTP_TIMEOUT_MS ?? '15000');
+  const allowInvalidCert = process.env.SMTP_REJECT_UNAUTHORIZED === 'false';
+
+  const socket = secure
+    ? tls.connect({
+        host,
+        port,
+        rejectUnauthorized: !allowInvalidCert,
+      })
+    : net.createConnection({ host, port });
+
+  socket.setEncoding('utf8');
+  socket.setTimeout(timeoutMs, () => {
+    socket.destroy(new Error('SMTP connection timed out'));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const event = secure ? 'secureConnect' : 'connect';
+    const onError = (error: Error) => {
+      socket.off(event, onConnect);
+      reject(error);
+    };
+    const onConnect = () => {
+      socket.off('error', onError);
+      resolve();
+    };
+    socket.once(event, onConnect);
+    socket.once('error', onError);
+  });
+
+  const waitForCode = (code: string) =>
+    new Promise<string>((resolve, reject) => {
+      let buffer = '';
+
+      const onData = (chunk: string) => {
+        buffer += chunk;
+        const lines = buffer.split(/\r?\n/).filter(line => line.length > 0);
+        if (lines.length === 0) return;
+        const lastLine = lines[lines.length - 1];
+        if (lastLine.startsWith(`${code} `)) {
+          cleanup();
+          resolve(buffer);
+        } else if (/^\d{3} /.test(lastLine) && !lastLine.startsWith(`${code} `)) {
+          cleanup();
+          reject(new Error(`SMTP error (expected ${code}): ${lastLine}`));
+        }
+      };
+
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const onClose = () => {
+        cleanup();
+        reject(new Error('SMTP connection closed before completing command'));
+      };
+
+      const cleanup = () => {
+        socket.off('data', onData);
+        socket.off('error', onError);
+        socket.off('end', onClose);
+        socket.off('close', onClose);
+      };
+
+      socket.on('data', onData);
+      socket.once('error', onError);
+      socket.once('end', onClose);
+      socket.once('close', onClose);
+    });
+
+  const sendCommand = async (command: string, expectedCode: string) => {
+    const responsePromise = waitForCode(expectedCode);
+    socket.write(`${command}\r\n`);
+    return responsePromise;
+  };
+
+  try {
+    await waitForCode('220');
+    await sendCommand(`EHLO ${helo}`, '250');
+
+    if (user && password) {
+      await sendCommand('AUTH LOGIN', '334');
+      await sendCommand(Buffer.from(user).toString('base64'), '334');
+      await sendCommand(Buffer.from(password).toString('base64'), '235');
+    }
+
+    await sendCommand(`MAIL FROM:<${options.from}>`, '250');
+    await sendCommand(`RCPT TO:<${options.to}>`, '250');
+    await sendCommand('DATA', '354');
+
+    const body = `${options.text}`;
+    const headers = [
+      `From: ${options.from}`,
+      `To: ${options.to}`,
+      `Subject: ${options.subject}`,
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset=utf-8',
+    ].join('\r\n');
+
+    const dataResponse = waitForCode('250');
+    socket.write(`${headers}\r\n\r\n${body}\r\n.\r\n`);
+    await dataResponse;
+
+    await sendCommand('QUIT', '221');
+  } finally {
+    if (!socket.destroyed) {
+      socket.end();
+    }
+  }
+}
+
+function stripHtml(value: string): string {
+  return value.replace(/<[^>]+>/g, ' ');
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, char => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case '\'':
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
+}
+
+function buildHtmlBody(items: OutOfStockEmailItem[], userEmail?: string | null): string {
+  const list = items
+    .map(item => `<li><strong>${escapeHtml(item.productName)}</strong> (SKU: ${escapeHtml(item.sku)})</li>`)
+    .join('');
+
+  const intro = '<p>The following items have just reached zero stock:</p>';
+  const outro = userEmail ? `<p>Updated by: ${escapeHtml(userEmail)}</p>` : '';
+
+  return `${intro}<ul>${list}</ul>${outro}`;
+}
+
+async function safeReadResponse(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '<no body>';
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable email helper that can deliver via SendGrid, Supabase Edge Functions, or direct SMTP using environment credentials
- trigger stockout detection and outbound notifications when inventory updates reduce a SKU to zero
- surface notification status in the scan page UI and document required configuration/env vars

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c865ab80148328b6dae3557d7433d1