### PR TITLE
Notify Slack when stock is depleted

### DIFF
--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -166,6 +166,10 @@ export default function ScanPage() {
             const result = await response.json();
             if (result.success) {
                 toast('Inventories updated');
+                if (Array.isArray(result.outOfStockItems) && result.outOfStockItems.length > 0) {
+                    const skuList = result.outOfStockItems.map((item: { sku: string }) => item.sku).join(', ');
+                    toast(`The following SKUs are now out of stock: ${skuList}`);
+                }
                 setScannedItems([]);
             } else {
                 toast(result.error || 'Failed to update inventories');


### PR DESCRIPTION
## Summary
- detect SKUs that become out of stock during the stock update API
- send a Slack webhook notification listing the depleted SKUs and return them in the API response
- surface a toast on the scan page to inform the user which scanned SKUs are now out of stock

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c876f32fb4832886e793e14eb3bc87