### PR TITLE
Add supply category filter to supplies page

### DIFF
--- a/src/features/supplies/SupplyCategoryFilter.tsx
+++ b/src/features/supplies/SupplyCategoryFilter.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+type SupplyCategoryFilterProps = {
+    categories: { id: string; category_name: string }[];
+    selectedCategory: string;
+};
+
+export function SupplyCategoryFilter({ categories, selectedCategory }: SupplyCategoryFilterProps) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const [value, setValue] = useState(selectedCategory);
+
+    useEffect(() => {
+        setValue(selectedCategory);
+    }, [selectedCategory]);
+
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const newValue = event.target.value;
+        setValue(newValue);
+
+        const params = new URLSearchParams(searchParams.toString());
+
+        if (newValue) {
+            params.set('category', newValue);
+        } else {
+            params.delete('category');
+        }
+
+        params.set('page', '1');
+
+        const queryString = params.toString();
+        router.push(queryString ? `${pathname}?${queryString}` : pathname);
+    };
+
+    return (
+        <select value={value} onChange={handleChange} aria-label="Filter supplies by category">
+            <option value="">All categories</option>
+            {categories.map(category => (
+                <option key={category.id} value={category.id}>
+                    {category.category_name}
+                </option>
+            ))}
+        </select>
+    );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -148,9 +148,23 @@ main {
 }
 
 .supplies-filter-bar {
+    align-items: center;
     align-self: center;
     display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
     justify-content: space-between;
+}
+
+.supplies-filter-bar .filter-bar-wrapper {
+    align-items: center;
+    display: flex;
+    flex: 1;
+    gap: 0.75rem;
+}
+
+.supplies-filter-bar select {
+    min-width: 180px;
 }
 
 .section-subtitle {


### PR DESCRIPTION
## Summary
- fetch supply categories on the supplies page and pass them to a new filter component
- add a client-side filter control that updates the category query param and resets pagination
- tweak the supplies filter bar styles so the new dropdown aligns with the existing search and settings controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfe11378f88328b128a4eb12105ee1