### PR TITLE
Add supply quantity field to supply management UI

### DIFF
--- a/src/app/api/supplies/addNewSupply/route.ts
+++ b/src/app/api/supplies/addNewSupply/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { supply_name, supply_category_id } = body;
+    const { supply_name, supply_category_id, supply_quantity } = body;
 
     if (!supply_name || supply_name.trim() === '') {
       return new Response(JSON.stringify({ success: false, error: 'Supply name is required' }), { status: 400 });
@@ -19,12 +19,18 @@ export async function POST(request: Request) {
       return new Response(JSON.stringify({ success: false, error: 'Category is required' }), { status: 400 });
     }
 
+    const parsedQuantity = Number(supply_quantity);
+    if (!Number.isFinite(parsedQuantity) || parsedQuantity < 0) {
+      return new Response(JSON.stringify({ success: false, error: 'Quantity must be a non-negative number' }), { status: 400 });
+    }
+
     const { data, error } = await supabase
       .from('supplies')
       .insert([
         {
           supply_name,
           supply_category_id,
+          supply_quantity: parsedQuantity,
           owner_id: user.id,
         },
       ]);

--- a/src/app/api/supplies/updateSupply/route.ts
+++ b/src/app/api/supplies/updateSupply/route.ts
@@ -5,17 +5,22 @@ export async function PUT(request: Request) {
   const supabase = await createClient();
 
   const body = await request.json();
-  const { id, supply_name, supply_category_id } = body;
+  const { id, supply_name, supply_category_id, supply_quantity } = body;
 
   if (!id || !supply_name) {
     return NextResponse.json({ error: 'Missing data' }, { status: 400 });
+  }
+
+  const parsedQuantity = Number(supply_quantity);
+  if (!Number.isFinite(parsedQuantity) || parsedQuantity < 0) {
+    return NextResponse.json({ error: 'Quantity must be a non-negative number' }, { status: 400 });
   }
 
   console.log('Updating supply:', { id, supply_name });
 
   const { data, error } = await supabase
     .from('supplies')
-    .update({ supply_name, supply_category_id })
+    .update({ supply_name, supply_category_id, supply_quantity: parsedQuantity })
     .eq('id', id)
     .select();
 

--- a/src/app/supplies/page.tsx
+++ b/src/app/supplies/page.tsx
@@ -23,10 +23,12 @@ export default async function SuppliesPage({ searchParams }: { searchParams: any
     const selectedCategoryId = categoryParam || "";
     const pageSize = 12;
 
-    const { data: supplyCategories = [] } = await supabase
+    const { data: supplyCategoriesData } = await supabase
         .from('supply_categories')
         .select('id, category_name')
         .order('category_name', { ascending: true });
+
+    const supplyCategories = supplyCategoriesData ?? [];
 
     let queryBuilder = supabase
         .from('supplies')

--- a/src/app/supplies/page.tsx
+++ b/src/app/supplies/page.tsx
@@ -21,6 +21,7 @@ export default async function SuppliesPage({ searchParams }: { searchParams: any
         .select(
             `id,
             supply_name,
+            supply_quantity,
             supply_category_id,
             supply_categories(id, category_name)`,
             { count: 'exact' }
@@ -51,6 +52,7 @@ export default async function SuppliesPage({ searchParams }: { searchParams: any
                     <thead>
                         <tr>
                             <th>Supply name</th>
+                            <th>Quantity</th>
                             <th>Supply category</th>
                             <th></th>
                         </tr>
@@ -60,6 +62,9 @@ export default async function SuppliesPage({ searchParams }: { searchParams: any
                             <tr key={supply.id}>
                                 <td><span className="item-name">{supply.supply_name}</span></td>
                                 <td>
+                                    <span className="item-name">{supply.supply_quantity ?? 0}</span>
+                                </td>
+                                <td>
                                     <div className="category-badge">
                                         {(supply.supply_categories as any)?.category_name}
                                     </div>
@@ -68,7 +73,12 @@ export default async function SuppliesPage({ searchParams }: { searchParams: any
                                     <div className="table-actions">
                                         <DeleteButton supplyId={supply.id} supplyName={supply.supply_name} />
                                         <ViewBatchButton supplyId={supply.id} />
-                                        <EditSupplyButton supplyId={supply.id} currentName={supply.supply_name} currentCategoryId={supply.supply_category_id} />
+                                        <EditSupplyButton
+                                            supplyId={supply.id}
+                                            currentName={supply.supply_name}
+                                            currentCategoryId={supply.supply_category_id}
+                                            currentQuantity={supply.supply_quantity}
+                                        />
                                     </div>
                                 </td>
                             </tr>

--- a/src/features/supplies/CategoryFilter.tsx
+++ b/src/features/supplies/CategoryFilter.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export type SupplyCategory = {
+    id: string | number;
+    category_name: string;
+};
+
+type Props = {
+    categories: SupplyCategory[];
+    selectedCategoryId?: string;
+};
+
+export function CategoryFilter({ categories, selectedCategoryId = "" }: Props) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const [value, setValue] = useState<string>(selectedCategoryId);
+
+    useEffect(() => {
+        setValue(selectedCategoryId);
+    }, [selectedCategoryId]);
+
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const nextValue = event.target.value;
+        setValue(nextValue);
+
+        const params = new URLSearchParams(searchParams.toString());
+
+        if (nextValue) {
+            params.set("category", nextValue);
+        } else {
+            params.delete("category");
+        }
+
+        params.set("page", "1");
+
+        router.push(`${pathname}?${params.toString()}`);
+    };
+
+    return (
+        <div className="filter-option">
+            <select
+                id="supplies-category-filter"
+                value={value}
+                onChange={handleChange}
+                aria-label="Filter by category"
+                disabled={categories.length === 0}
+            >
+                <option value="">All categories</option>
+                {categories.map((category) => (
+                    <option key={category.id} value={String(category.id)}>
+                        {category.category_name}
+                    </option>
+                ))}
+            </select>
+        </div>
+    );
+}

--- a/src/features/supplies/add/AddSupplyDialog.tsx
+++ b/src/features/supplies/add/AddSupplyDialog.tsx
@@ -14,6 +14,7 @@ type Props = {
 export function AddSupplyDialog({ open, onClose }: Props) {
     const [supplyName, setSupplyName] = useState('');
     const [supplyCategoryId, setSupplyCategoryId] = useState('');
+    const [supplyQuantity, setSupplyQuantity] = useState('');
     const [categories, setCategories] = useState<{ id: string; category_name: string }[]>([]);
     const toast = useToast();
     const router = useRouter();
@@ -37,9 +38,19 @@ export function AddSupplyDialog({ open, onClose }: Props) {
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
+        const parsedQuantity = Number(supplyQuantity);
+        if (!Number.isFinite(parsedQuantity) || parsedQuantity < 0) {
+            toast('Quantity must be a non-negative number');
+            return;
+        }
+
         const response = await fetch('/api/supplies/addNewSupply', {
             method: 'POST',
-            body: JSON.stringify({ supply_name: supplyName, supply_category_id: supplyCategoryId }),
+            body: JSON.stringify({
+                supply_name: supplyName,
+                supply_category_id: supplyCategoryId,
+                supply_quantity: parsedQuantity,
+            }),
             headers: { 'Content-Type': 'application/json' },
         });
 
@@ -51,6 +62,7 @@ export function AddSupplyDialog({ open, onClose }: Props) {
             onClose();
             setSupplyName('');
             setSupplyCategoryId('');
+            setSupplyQuantity('');
         } else {
             toast(`Error: ${result.error}`);
         }
@@ -62,6 +74,17 @@ export function AddSupplyDialog({ open, onClose }: Props) {
                 <div className="input-group">
                     <label className="input-label">Name</label>
                     <input value={supplyName} onChange={(e) => setSupplyName(e.target.value)} required />
+                </div>
+
+                <div className="input-group">
+                    <label className="input-label">Quantity</label>
+                    <input
+                        type="number"
+                        min="0"
+                        value={supplyQuantity}
+                        onChange={(e) => setSupplyQuantity(e.target.value)}
+                        required
+                    />
                 </div>
 
                 <div className="input-group">

--- a/src/features/supplies/edit/EditSupplyButton.tsx
+++ b/src/features/supplies/edit/EditSupplyButton.tsx
@@ -8,9 +8,10 @@ type Props = {
     supplyId: string;
     currentName: string;
     currentCategoryId: string;
+    currentQuantity: number | null;
 };
 
-export function EditSupplyButton({ supplyId, currentName, currentCategoryId }: Props) {
+export function EditSupplyButton({ supplyId, currentName, currentCategoryId, currentQuantity }: Props) {
     const [open, setOpen] = useState(false);
 
     return (
@@ -22,6 +23,7 @@ export function EditSupplyButton({ supplyId, currentName, currentCategoryId }: P
                     id={supplyId}
                     currentName={currentName}
                     currentCategoryId={currentCategoryId}
+                    currentQuantity={currentQuantity ?? 0}
                     open={open}
                     onClose={() => setOpen(false)}
                 />

--- a/src/features/supplies/edit/EditSupplyDialog.tsx
+++ b/src/features/supplies/edit/EditSupplyDialog.tsx
@@ -10,13 +10,15 @@ type EditSupplyDialogProps = {
     id: string;
     currentName: string;
     currentCategoryId: string;
+    currentQuantity: number;
     open: boolean;
     onClose: () => void;
 };
 
-export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onClose }: EditSupplyDialogProps) {
+export function EditSupplyDialog({ id, currentName, currentCategoryId, currentQuantity, open, onClose }: EditSupplyDialogProps) {
     const [supplyName, setSupplyName] = useState(currentName);
     const [supplyCategoryId, setSupplyCategoryId] = useState(currentCategoryId);
+    const [supplyQuantity, setSupplyQuantity] = useState<string>(String(currentQuantity ?? 0));
     const [categories, setCategories] = useState<{ id: string; category_name: string }[]>([]);
     const toast = useToast();
     const router = useRouter();
@@ -25,6 +27,7 @@ export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onC
         if (open) {
             setSupplyName(currentName);
             setSupplyCategoryId(currentCategoryId);
+            setSupplyQuantity(String(currentQuantity ?? 0));
             const load = async () => {
                 try {
                     const res = await fetch('/api/supplyCategories');
@@ -38,10 +41,16 @@ export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onC
             };
             load();
         }
-    }, [open, currentName, currentCategoryId]);
+    }, [open, currentName, currentCategoryId, currentQuantity]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+
+        const parsedQuantity = Number(supplyQuantity);
+        if (!Number.isFinite(parsedQuantity) || parsedQuantity < 0) {
+            toast('Quantity must be a non-negative number');
+            return;
+        }
 
         const response = await fetch(`/api/supplies/updateSupply`, {
             method: 'PUT',
@@ -49,6 +58,7 @@ export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onC
                 id,
                 supply_name: supplyName,
                 supply_category_id: supplyCategoryId,
+                supply_quantity: parsedQuantity,
             }),
             headers: {
                 'Content-Type': 'application/json',
@@ -72,6 +82,17 @@ export function EditSupplyDialog({ id, currentName, currentCategoryId, open, onC
                 <div className="input-group">
                     <label className="input-label">Name</label>
                     <input value={supplyName} onChange={(e) => setSupplyName(e.target.value)} required />
+                </div>
+
+                <div className="input-group">
+                    <label className="input-label">Quantity</label>
+                    <input
+                        type="number"
+                        min="0"
+                        value={supplyQuantity}
+                        onChange={(e) => setSupplyQuantity(e.target.value)}
+                        required
+                    />
                 </div>
 
                 <div className="input-group">


### PR DESCRIPTION
## Summary
- add the supply quantity column to the supplies list and wire it through the edit dialog
- collect and validate quantity values in the add and edit supply forms
- persist quantity updates through the add and update supply API routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd54786dac83289589dd807349c72a